### PR TITLE
Add the ability to emit index entries.

### DIFF
--- a/packages/lit-analyzer/src/analyze/parse/document/text-document/html-document/html-document.ts
+++ b/packages/lit-analyzer/src/analyze/parse/document/text-document/html-document/html-document.ts
@@ -80,20 +80,16 @@ export class HtmlDocument extends TextDocument {
 		return items;
 	}
 
-	private mapFindOne<T>(map: (node: HtmlNode) => T | undefined): T | undefined {
-		function innerTest(node: HtmlNode): T | undefined {
-			const res = map(node);
-			if (res) return res;
-
-			for (const childNode of node.children || []) {
-				const found = innerTest(childNode);
-				if (found != null) return found;
-			}
-			return;
+	*nodes(roots = this.rootNodes): IterableIterator<HtmlNode> {
+		for (const root of roots) {
+			yield root;
+			yield* this.nodes(root.children);
 		}
+	}
 
-		for (const rootNode of this.rootNodes || []) {
-			const found = innerTest(rootNode);
+	private mapFindOne<T>(map: (node: HtmlNode) => T | undefined): T | undefined {
+		for (const node of this.nodes()) {
+			const found = map(node);
 			if (found != null) {
 				return found;
 			}


### PR DESCRIPTION
I'm prototyping a Kythe TypeScript indexer plugin and things are fitting together pretty well! This same method should also be useful for generating the language server index format.

This starts by adding a method on the analyzer that will yield all of the information that the analyzer has determined about a file. I started with element and attribute references as they seem like the most valuable. What else could we emit here?