### PR TITLE
Initial security type checking.

### DIFF
--- a/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
+++ b/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
@@ -136,9 +136,12 @@ export function litDiagnosticRuleSeverity(config: LitAnalyzerConfig, ruleName: L
 
 export type LitAnalyzerLogging = "off" | "error" | "warn" | "debug" | "verbose";
 
+export type LitSecuritySystem = "off" | "ClosureSafeTypes";
+
 export interface LitAnalyzerConfig {
 	strict: boolean;
 	rules: LitAnalyzerRules;
+	securitySystem: LitSecuritySystem;
 
 	disable: boolean;
 	logging: LitAnalyzerLogging;
@@ -165,6 +168,7 @@ export function makeConfig(userOptions: Partial<LitAnalyzerConfig> = {}): LitAna
 	return {
 		strict: userOptions.strict || false,
 		rules: makeRules(userOptions),
+		securitySystem: userOptions.securitySystem || "off",
 
 		disable: userOptions.disable || false,
 		logging: userOptions.logging || "off",

--- a/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
+++ b/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
@@ -160,11 +160,27 @@ export interface LitAnalyzerConfig {
 	customHtmlData: (string | HtmlData)[] | string | HtmlData;
 }
 
+function expectNever(never: never) {
+	return never;
+}
+
 /**
  * Parses a partial user configuration and returns a full options object with defaults.
  * @param userOptions
  */
 export function makeConfig(userOptions: Partial<LitAnalyzerConfig> = {}): LitAnalyzerConfig {
+	let securitySystem = userOptions.securitySystem || "off";
+	switch (securitySystem) {
+		case "off":
+		case "ClosureSafeTypes":
+			break; // legal values
+		default:
+			// Log an error here? Or maybe throw?
+			expectNever(securitySystem);
+			// Unknown values get converted to "off".
+			securitySystem = "off";
+	}
+
 	return {
 		strict: userOptions.strict || false,
 		rules: makeRules(userOptions),

--- a/packages/lit-analyzer/src/analyze/util/type/is-assignable-binding-under-security-system.ts
+++ b/packages/lit-analyzer/src/analyze/util/type/is-assignable-binding-under-security-system.ts
@@ -1,0 +1,109 @@
+import { HtmlNodeAttr } from "../../types/html-node/html-node-attr-types";
+import { SimpleType, toTypeString, SimpleTypeKind } from "ts-simple-type";
+import { LitAnalyzerRequest } from "../../lit-analyzer-context";
+import { LitHtmlDiagnostic, LitHtmlDiagnosticKind } from "../../types/lit-diagnostic";
+import { LitAnalyzerRuleName } from "../../lit-analyzer-config";
+
+/**
+ * If the user's security policy overrides normal type checking for this
+ * attribute binding, returns a (possibly empty) array of diagnostics.
+ *
+ * If the security policy does not apply to this binding, then
+ */
+export function isAssignableBindingUnderSecuritySystem(
+	htmlAttr: HtmlNodeAttr,
+	{ typeA, typeB }: { typeA: SimpleType; typeB: SimpleType },
+	request: LitAnalyzerRequest,
+	source: LitAnalyzerRuleName
+): LitHtmlDiagnostic[] | undefined {
+	const securityPolicy = request.config.securitySystem;
+	switch (securityPolicy) {
+		case "off":
+			return undefined; // No security checks apply.
+		case "ClosureSafeTypes":
+			return checkClosureSecurityAssignability(typeB, htmlAttr, request, source);
+		default: {
+			const never: never = securityPolicy;
+			request.logger.error(`Unexpected security policy: ${never}`);
+			return undefined;
+		}
+	}
+}
+
+interface TagNameToSecurityOverrideMap {
+	[tagName: string]: SecurityOverrideMap | undefined;
+}
+
+// A map from attribute/property names to an array of type names.
+// Assignments to the given attribute must match one of the given types.
+interface SecurityOverrideMap {
+	[attributeName: string]: string[] | undefined;
+}
+
+const closureScopedOverrides: TagNameToSecurityOverrideMap = {
+	iframe: {
+		src: ["TrustedResourceUrl"]
+	},
+	a: {
+		href: ["TrustedResourceUrl", "SafeUrl"]
+	},
+	img: {
+		src: ["TrustedResourceUrl", "SafeUrl"]
+	},
+	script: {
+		src: ["TrustedResourceUrl"]
+	}
+};
+const closureGlobalOverrides: SecurityOverrideMap = {
+	style: ["SafeStyle"]
+};
+
+function checkClosureSecurityAssignability(
+	typeB: SimpleType,
+	htmlAttr: HtmlNodeAttr,
+	request: LitAnalyzerRequest,
+	source: LitAnalyzerRuleName
+): LitHtmlDiagnostic[] | undefined {
+	const scopedOverride = closureScopedOverrides[htmlAttr.htmlNode.tagName];
+	const overriddenTypes = (scopedOverride && scopedOverride[htmlAttr.name]) || closureGlobalOverrides[htmlAttr.name];
+	if (overriddenTypes === undefined) {
+		return undefined;
+	}
+	if (!matchesAtLeastOneNominalType(overriddenTypes, typeB)) {
+		const nominalType: SimpleType = {
+			kind: SimpleTypeKind.INTERFACE,
+			members: [],
+			name: "A security type"
+		};
+		return [
+			{
+				kind: LitHtmlDiagnosticKind.INVALID_ATTRIBUTE_EXPRESSION_TYPE,
+				message: `Type '${toTypeString(typeB)}' is not assignable to '${overriddenTypes.join(" | ")}'.`,
+				severity: "error",
+				source,
+				location: { document: request.document, ...htmlAttr.location.name },
+				htmlAttr,
+				typeA: nominalType,
+				typeB
+			}
+		];
+	}
+	return [];
+}
+
+function matchesAtLeastOneNominalType(typeNames: string[], typeB: SimpleType): boolean {
+	if (typeB.name !== undefined && typeNames.includes(typeB.name)) {
+		return true;
+	}
+	switch (typeB.kind) {
+		case "UNION":
+			return typeB.types.every(t => matchesAtLeastOneNominalType(typeNames, t));
+		case "STRING_LITERAL":
+		case "STRING":
+			return typeNames.includes("string");
+		case "GENERIC_ARGUMENTS":
+			return matchesAtLeastOneNominalType(typeNames, typeB.target);
+		default:
+			return false;
+	}
+}

--- a/packages/lit-analyzer/src/analyze/util/type/is-assignable-binding-under-security-system.ts
+++ b/packages/lit-analyzer/src/analyze/util/type/is-assignable-binding-under-security-system.ts
@@ -82,7 +82,7 @@ function checkClosureSecurityAssignability(
 		return [
 			{
 				kind: LitHtmlDiagnosticKind.INVALID_ATTRIBUTE_EXPRESSION_TYPE,
-				message: `Type '${toTypeString(typeB)}' is not assignable to '${overriddenTypes.join(" | ")}'.`,
+				message: `Type '${toTypeString(typeB)}' is not assignable to '${overriddenTypes.join(" | ")}'. This is due to Closure Safe Type enforcement.`,
 				severity: "error",
 				source,
 				location: { document: request.document, ...htmlAttr.location.name },

--- a/packages/lit-analyzer/src/analyze/util/type/is-assignable-in-attribute-binding.ts
+++ b/packages/lit-analyzer/src/analyze/util/type/is-assignable-in-attribute-binding.ts
@@ -42,8 +42,8 @@ export function isAssignableInAttributeBinding(
 			// <script src>).
 			const securityDiagnostics = isAssignableBindingUnderSecuritySystem(htmlAttr, { typeA, typeB }, request, "no-incompatible-type-binding");
 			if (securityDiagnostics !== undefined) {
-				// The security diagnostics are binding. Note that this may be an
-				// empty array.
+				// The security diagnostics take precedence here, and we should not
+				// do any more checking. Note that this may be an empty array.
 				return securityDiagnostics;
 			}
 		}

--- a/packages/lit-analyzer/src/analyze/util/type/is-assignable-in-property-binding.ts
+++ b/packages/lit-analyzer/src/analyze/util/type/is-assignable-in-property-binding.ts
@@ -4,12 +4,20 @@ import { LitAnalyzerRequest } from "../../lit-analyzer-context";
 import { HtmlNodeAttr } from "../../types/html-node/html-node-attr-types";
 import { LitHtmlDiagnostic, LitHtmlDiagnosticKind } from "../../types/lit-diagnostic";
 import { isAssignableToType } from "./is-assignable-to-type";
+import { isAssignableBindingUnderSecuritySystem } from "./is-assignable-binding-under-security-system";
 
 export function isAssignableInPropertyBinding(
 	htmlAttr: HtmlNodeAttr,
 	{ typeA, typeB }: { typeA: SimpleType; typeB: SimpleType },
 	request: LitAnalyzerRequest
 ): LitHtmlDiagnostic[] | undefined {
+	const securityDiagnostics = isAssignableBindingUnderSecuritySystem(htmlAttr, { typeA, typeB }, request, "no-incompatible-type-binding");
+	if (securityDiagnostics !== undefined) {
+		// The security diagnostics are binding. Note that this may be an
+		// empty array.
+		return securityDiagnostics;
+	}
+
 	if (!isAssignableToType({ typeA, typeB }, request)) {
 		return [
 			{

--- a/packages/lit-analyzer/src/analyze/util/type/is-assignable-in-property-binding.ts
+++ b/packages/lit-analyzer/src/analyze/util/type/is-assignable-in-property-binding.ts
@@ -13,8 +13,8 @@ export function isAssignableInPropertyBinding(
 ): LitHtmlDiagnostic[] | undefined {
 	const securityDiagnostics = isAssignableBindingUnderSecuritySystem(htmlAttr, { typeA, typeB }, request, "no-incompatible-type-binding");
 	if (securityDiagnostics !== undefined) {
-		// The security diagnostics are binding. Note that this may be an
-		// empty array.
+		// The security diagnostics take precedence here, and we should not
+		// do any more checking. Note that this may be an empty array.
 		return securityDiagnostics;
 	}
 

--- a/packages/lit-analyzer/src/rules/no-complex-attribute-binding.ts
+++ b/packages/lit-analyzer/src/rules/no-complex-attribute-binding.ts
@@ -5,6 +5,7 @@ import { LitHtmlDiagnosticKind } from "../analyze/types/lit-diagnostic";
 import { RuleModule } from "../analyze/types/rule-module";
 import { isLitDirective } from "../analyze/util/directive/is-lit-directive";
 import { extractBindingTypes } from "../analyze/util/type/extract-binding-types";
+import { isAssignableBindingUnderSecuritySystem } from "../analyze/util/type/is-assignable-binding-under-security-system";
 
 /**
  * This rule validates that complex types are not used within an expression in an attribute binding.
@@ -23,6 +24,12 @@ const rule: RuleModule = {
 
 		// Only primitive types should be allowed as "typeB"
 		if (!isAssignableToPrimitiveType(typeB)) {
+			if (isAssignableBindingUnderSecuritySystem(htmlAttr, { typeA, typeB }, request, this.name) !== undefined) {
+				// This is binding via a security sanitization system, let it do
+				// this check. Apparently complex values are OK to assign here.
+				return undefined;
+			}
+
 			return [
 				{
 					kind: LitHtmlDiagnosticKind.COMPLEX_NOT_BINDABLE_IN_ATTRIBUTE_BINDING,

--- a/packages/lit-analyzer/test/rules/security-system.ts
+++ b/packages/lit-analyzer/test/rules/security-system.ts
@@ -70,7 +70,7 @@ test(testName, t => {
 	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
 });
 
-testName = "May pass either a SafeUrl or a TrustedResourceUrl to img src with ClosureSafeTypes config";
+testName = "May pass either a SafeUrl or a TrustedResourceUrl or a string to img src with ClosureSafeTypes config";
 test(testName, t => {
 	const { diagnostics } = getDiagnostics(preface + "html`<img src=${safeUrl}></script>`", { securitySystem: "ClosureSafeTypes" });
 	hasNoDiagnostics(t, diagnostics);
@@ -79,9 +79,14 @@ test(testName, t => {
 		securitySystem: "ClosureSafeTypes"
 	});
 	hasNoDiagnostics(t, moreDiagnostics);
+
+	const { diagnostics: evenMoreDiagnostics } = getDiagnostics(preface + "html`<img src=${'/img.webp'}></script>`", {
+		securitySystem: "ClosureSafeTypes"
+	});
+	hasNoDiagnostics(t, evenMoreDiagnostics);
 });
 
-testName = "May pass either a SafeUrl or a TrustedResourceUrl to img .src with ClosureSafeTypes config";
+testName = "May pass either a SafeUrl or a TrustedResourceUrl or a string to img .src with ClosureSafeTypes config";
 test(testName, t => {
 	const { diagnostics } = getDiagnostics(preface + "html`<img .src=${safeUrl}></script>`", { securitySystem: "ClosureSafeTypes" });
 	hasNoDiagnostics(t, diagnostics);
@@ -90,24 +95,23 @@ test(testName, t => {
 		securitySystem: "ClosureSafeTypes"
 	});
 	hasNoDiagnostics(t, moreDiagnostics);
+
+	const { diagnostics: evenMoreDiagnostics } = getDiagnostics(preface + "html`<img .src=${'/img.webp'}></script>`", {
+		securitySystem: "ClosureSafeTypes"
+	});
+	hasNoDiagnostics(t, evenMoreDiagnostics);
 });
 
-testName = "May not pass a string to img src with ClosureSafeTypes config";
-test(testName, t => {
-	const { diagnostics } = getDiagnostics(preface + 'html`<img src=${"/foo.webp"}></script>`', { securitySystem: "ClosureSafeTypes" });
-	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
-});
-
-testName = "May not pass a string to style with ClosureSafeTypes config";
+testName = "May pass a string to style with ClosureSafeTypes config";
 test(testName, t => {
 	const { diagnostics } = getDiagnostics(preface + 'html`<div style=${"color: red"}></div>`', { securitySystem: "ClosureSafeTypes" });
-	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
+	hasNoDiagnostics(t, diagnostics);
 });
 
-testName = "May not pass a string to .style with ClosureSafeTypes config";
+testName = "May pass a string to .style with ClosureSafeTypes config";
 test(testName, t => {
 	const { diagnostics } = getDiagnostics(preface + 'html`<div .style=${"color: red"}></div>`', { securitySystem: "ClosureSafeTypes" });
-	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
+	hasNoDiagnostics(t, diagnostics);
 });
 
 testName = "May pass a SafeStyle to style with ClosureSafeTypes config";

--- a/packages/lit-analyzer/test/rules/security-system.ts
+++ b/packages/lit-analyzer/test/rules/security-system.ts
@@ -1,0 +1,123 @@
+import test from "ava";
+import { getDiagnostics } from "../helpers/analyze";
+import { hasDiagnostic, hasNoDiagnostics } from "../helpers/assert";
+
+const preface = `
+  class TrustedResourceUrl {};
+  class SafeUrl {};
+  class SafeStyle {};
+
+  const trustedResourceUrl = new TrustedResourceUrl();
+  const safeUrl = new SafeUrl();
+  const safeStyle = new SafeStyle();
+`;
+
+test("May bind string to script src with default config", t => {
+	const { diagnostics } = getDiagnostics('html`<script .src=${"/foo.js"}></script>`', {});
+	hasNoDiagnostics(t, diagnostics);
+});
+
+test("May not bind string to script src with ClosureSafeTypes config", t => {
+	const { diagnostics } = getDiagnostics('html`<script src=${"/foo.js"}></script>`', { securitySystem: "ClosureSafeTypes" });
+	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
+});
+
+test("May not bind string to script .src with ClosureSafeTypes config", t => {
+	const { diagnostics } = getDiagnostics('html`<script .src=${"/foo.js"}></script>`', { securitySystem: "ClosureSafeTypes" });
+	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
+});
+
+test("May pass static string to script src with ClosureSafeTypes config", t => {
+	const { diagnostics } = getDiagnostics('html`<script src="/foo.js"></script>`', { securitySystem: "ClosureSafeTypes" });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+let testName = "May not pass a TrustedResourceUrl to script src with default config";
+test(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<script src=${trustedResourceUrl}></script>`");
+	hasDiagnostic(t, diagnostics, "no-complex-attribute-binding");
+});
+
+// Commented out because we're missing properties on built in elements like
+// script.
+testName = "May not pass a TrustedResourceUrl to script .src with default config";
+test.skip(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<script .src=${trustedResourceUrl}></script>`");
+	hasDiagnostic(t, diagnostics, "no-complex-attribute-binding");
+});
+
+testName = "May pass a TrustedResourceUrl to script src with ClosureSafeTypes config";
+test(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<script src=${trustedResourceUrl}></script>`", { securitySystem: "ClosureSafeTypes" });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+testName = "May pass a TrustedResourceUrl to script .src with ClosureSafeTypes config";
+test(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<script .src=${trustedResourceUrl}></script>`", { securitySystem: "ClosureSafeTypes" });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+testName = "May not pass a SafeUrl to script src with ClosureSafeTypes config";
+test(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<script src=${safeUrl}></script>`", { securitySystem: "ClosureSafeTypes" });
+	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
+});
+
+testName = "May not pass a SafeUrl to script .src with ClosureSafeTypes config";
+test(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<script .src=${safeUrl}></script>`", { securitySystem: "ClosureSafeTypes" });
+	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
+});
+
+testName = "May pass either a SafeUrl or a TrustedResourceUrl to img src with ClosureSafeTypes config";
+test(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<img src=${safeUrl}></script>`", { securitySystem: "ClosureSafeTypes" });
+	hasNoDiagnostics(t, diagnostics);
+
+	const { diagnostics: moreDiagnostics } = getDiagnostics(preface + "html`<img src=${trustedResourceUrl}></script>`", {
+		securitySystem: "ClosureSafeTypes"
+	});
+	hasNoDiagnostics(t, moreDiagnostics);
+});
+
+testName = "May pass either a SafeUrl or a TrustedResourceUrl to img .src with ClosureSafeTypes config";
+test(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<img .src=${safeUrl}></script>`", { securitySystem: "ClosureSafeTypes" });
+	hasNoDiagnostics(t, diagnostics);
+
+	const { diagnostics: moreDiagnostics } = getDiagnostics(preface + "html`<img .src=${trustedResourceUrl}></script>`", {
+		securitySystem: "ClosureSafeTypes"
+	});
+	hasNoDiagnostics(t, moreDiagnostics);
+});
+
+testName = "May not pass a string to img src with ClosureSafeTypes config";
+test(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + 'html`<img src=${"/foo.webp"}></script>`', { securitySystem: "ClosureSafeTypes" });
+	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
+});
+
+testName = "May not pass a string to style with ClosureSafeTypes config";
+test(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + 'html`<div style=${"color: red"}></div>`', { securitySystem: "ClosureSafeTypes" });
+	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
+});
+
+testName = "May not pass a string to .style with ClosureSafeTypes config";
+test(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + 'html`<div .style=${"color: red"}></div>`', { securitySystem: "ClosureSafeTypes" });
+	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
+});
+
+testName = "May pass a SafeStyle to style with ClosureSafeTypes config";
+test(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<div style=${safeStyle}></div>`", { securitySystem: "ClosureSafeTypes" });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+testName = "May pass a SafeStyle to .style with ClosureSafeTypes config";
+test(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<div .style=${safeStyle}></div>`", { securitySystem: "ClosureSafeTypes" });
+	hasNoDiagnostics(t, diagnostics);
+});

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -91,6 +91,15 @@
 						"description": "Enable strict mode.",
 						"default": false
 					},
+					"lit-plugin.securitySystem": {
+						"type": "string",
+						"description": "The lit-html security sanitization strategy to assume.",
+						"default": "off",
+						"enum": [
+							"off",
+							"ClosureSafeTypes"
+						]
+					},
 					"lit-plugin.htmlTemplateTags": {
 						"type": "array",
 						"description": "List of template tags to enable html support in.",

--- a/packages/vscode-lit-plugin/schemas/tsconfig.schema.json
+++ b/packages/vscode-lit-plugin/schemas/tsconfig.schema.json
@@ -29,6 +29,12 @@
 									"description": "Enable strict mode.",
 									"default": false
 								},
+								"securitySystem": {
+									"type": "string",
+									"description": "The lit-html security sanitization strategy to assume.",
+									"default": "off",
+									"enum": ["off", "ClosureSafeTypes"]
+								},
 								"htmlTemplateTags": {
 									"type": "array",
 									"description": "List of template tags to enable html support in.",

--- a/packages/vscode-lit-plugin/src/extension.ts
+++ b/packages/vscode-lit-plugin/src/extension.ts
@@ -105,6 +105,9 @@ function getConfig(): Partial<LitAnalyzerConfig> {
 	withConfigValue(config, "strict", value => {
 		outConfig.strict = value;
 	});
+	withConfigValue(config, "securitySystem", value => {
+		outConfig.securitySystem = value;
+	});
 
 	// Template tags
 	withConfigValue(config, "htmlTemplateTags", value => {


### PR DESCRIPTION
This adds basic support for type checking code with Safe Types sanitization in place. This can be trivially extended to support checking with Trusted Types, but I'm starting simple.

Trusted Types is also still working through the standards process, so I don't want to ship anything prematurely here. See the conversation at https://groups.google.com/a/chromium.org/g/blink-dev/c/Il-wfnw9TAw

Fixes #28 