### PR TITLE
Use < and > in tag name error messages.

### DIFF
--- a/packages/lit-analyzer/src/rules/no-unknown-tag-name.ts
+++ b/packages/lit-analyzer/src/rules/no-unknown-tag-name.ts
@@ -31,8 +31,8 @@ const rule: RuleModule = {
 			return [
 				{
 					kind: LitHtmlDiagnosticKind.UNKNOWN_TAG,
-					message: `Unknown tag "${htmlNode.tagName}".`,
-					fix: suggestedName == null ? undefined : `Did you mean '${suggestedName}'?`,
+					message: `Unknown tag <${htmlNode.tagName}>.`,
+					fix: suggestedName == null ? undefined : `Did you mean <${suggestedName}>?`,
 					location: { document, ...htmlNode.location.name },
 					source: "no-unknown-tag-name",
 					severity: litDiagnosticRuleSeverity(config, "no-unknown-tag-name"),


### PR DESCRIPTION
IMO it's faster to read and know that it's a tag name if it's written <like-this>