### PR TITLE
Transpile only in ava config

### DIFF
--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -65,7 +65,7 @@
 			"ts"
 		],
 		"require": [
-			"ts-node/register"
+			"ts-node/register/transpile-only"
 		],
 		"snapshotDir": "test/snapshots/results",
 		"files": [


### PR DESCRIPTION
This gives faster test running, though it does not validate that the code type checks. `npm run build` will, and when developing your editor will tell you about type errors.