### PR TITLE
Fixes css list substitution bug

### DIFF
--- a/packages/lit-analyzer/src/analyze/parse/document/virtual-document/virtual-css-document.ts
+++ b/packages/lit-analyzer/src/analyze/parse/document/virtual-document/virtual-css-document.ts
@@ -3,7 +3,7 @@ import { VirtualAstDocument } from "./virtual-ast-document";
 
 export class VirtualAstCssDocument extends VirtualAstDocument {
 	protected substituteExpression(length: number, expression: Expression, prev: string, next: string | undefined): string {
-		const hasLeftColon = prev.match(/:\s*\${$/) != null;
+		const hasLeftColon = prev.match(/:[^;{]*\${$/) != null;
 		const hasRightColon = next != null && next.match(/^}\s*:\s+/) != null;
 		const hasRightSemicolon = next != null && next.match(/^}\s*;/) != null;
 		const hasRightPercentage = next != null && next.match(/^}%/) != null;

--- a/packages/lit-analyzer/test/parser/css-document/css-substitutions.ts
+++ b/packages/lit-analyzer/test/parser/css-document/css-substitutions.ts
@@ -1,0 +1,45 @@
+import { ExecutionContext } from "ava";
+import test from "ava";
+
+import { compileFiles } from "../../helpers/compile-files";
+import { findTaggedTemplates } from "../../../src/analyze/parse/tagged-template/find-tagged-templates";
+import { CssDocument } from "../../../src/analyze/parse/document/text-document/css-document/css-document";
+import { VirtualAstCssDocument } from "../../../src/analyze/parse/document/virtual-document/virtual-css-document";
+
+function createCssDocument(testFile: string) {
+	const { sourceFile } = compileFiles(testFile);
+	const taggedTemplates = findTaggedTemplates(sourceFile, ["css"]);
+	return new CssDocument(new VirtualAstCssDocument(taggedTemplates[0]));
+}
+
+function isTemplateText(t: ExecutionContext, text: string, testFile: string) {
+	t.is(text, createCssDocument(testFile).virtualDocument.text);
+}
+
+test("Substitute for template followed by percent", t => {
+	isTemplateText(t, "{ div { transform-origin: 0000% 0000%; } }", "css`{ div { transform-origin: ${x}% ${y}%; } }`");
+});
+
+test("Substitute for template last in css list", t => {
+	isTemplateText(t, "{ div { border: 2px solid ________; } }", "css`{ div { border: 2px solid ${COLOR}; } }`");
+});
+
+test("Substitute for template first in css list", t => {
+	isTemplateText(t, "{ div { border: ________ solid #ffffff; } }", "css`{ div { border: ${WIDTH} solid #ffffff; } }`");
+});
+
+test("Substitute for template middle in css list", t => {
+	isTemplateText(t, "{ div { border: 2px ________ #ffffff; } }", "css`{ div { border: 2px ${STYLE} #ffffff; } }`");
+});
+
+test("Substitute for template css key-value pair", t => {
+	isTemplateText(t, "{ div { $_:_______________________; } }", "css`{ div { ${unsafeCSS('color: red')}; } }`");
+});
+
+test("Substitute for template css value only", t => {
+	isTemplateText(t, "{ div { color: ___________________; } }", "css`{ div { color: ${unsafeCSS('red')}; } }`");
+});
+
+test("Substitute for template css key only", t => {
+	isTemplateText(t, "{ div { $____________________: red; } }", "css`{ div { ${unsafeCSS('color')}: red; } }`");
+});


### PR DESCRIPTION
If you had a css list and the last item was a template, then the substituter would incorrectly replace it with $_:_____, thinking it was a full key/value replacement. This was because it didn't search past the beginning of the list to look for the colon (:) character. To fix this, I modified the regex for the previous colon to search anything that isn't a semi-colon or left curly. This way it can find the colon and properly replace with _______.

This addresses an issue I posted: https://github.com/runem/lit-analyzer/issues/72