### PR TITLE
Handle circular type refs in matchesAtLeastOneNominalType

### DIFF
--- a/packages/lit-analyzer/src/analyze/util/type/is-assignable-binding-under-security-system.ts
+++ b/packages/lit-analyzer/src/analyze/util/type/is-assignable-binding-under-security-system.ts
@@ -109,6 +109,8 @@ function matchesAtLeastOneNominalType(typeNames: string[], typeB: SimpleType): b
 			return typeNames.includes("string");
 		case "GENERIC_ARGUMENTS":
 			return matchesAtLeastOneNominalType(typeNames, typeB.target);
+		case "CIRCULAR_TYPE_REF":
+			return matchesAtLeastOneNominalType(typeNames, typeB.ref);
 		default:
 			return false;
 	}


### PR DESCRIPTION
Using the simple types cache more aggressively resulted in one compilation failing due to a circular type ref here.