### PR TITLE
performance: import traversal

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_size = 1
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,7 @@
 root = true
 
 [*]
-indent_size = 1
+charset = utf-8
+indent_size = tab
 indent_style = tab
+tab_width = 2

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 /.vsCode
 .idea
+.editorconfig
 node_modules
 *.txt
 *.tgz

--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -56,7 +56,9 @@ export function visitDependencies(node: Node, context: IVisitDependenciesContext
 			return;
 		}
 	} else if (context.ts.isImportDeclaration(node) || context.ts.isExportDeclaration(node)) {
-		if (node.moduleSpecifier != null && context.ts.isStringLiteral(node.moduleSpecifier)) {
+		if (node.moduleSpecifier != null && context.ts.isStringLiteral(node.moduleSpecifier) &&
+				context.ts.isSourceFile(node.parent) &&
+				!context.program.isSourceFileFromExternalLibrary(node.parent)) {
 			visitModuleWithName(node.moduleSpecifier.text, node, context);
 		}
 	} else if (context.ts.isCallExpression(node) && node.expression.kind === context.ts.SyntaxKind.ImportKeyword) {


### PR DESCRIPTION
analysis takes an incredible amount of time in some of my repos, so i have profiled it and tested it today...

almost all the CPU time is lost to traversal of the dependency graph, i.e. simply the massive amount of recursive calls in `visitDependencies` reach an unreasonable level.

what do you think of this?

the change is to **only visit imported modules which we imported directly, not from external libraries**.

im making these assumptions:

* web-analyzer has already parsed direct imports by this point i imagine, so we already know what elements (and their properties etc) a direct import provides
* it is bad practice to rely on deeply nested imports out of your control to expose an element, you should import it directly

given these two assumptions, all imported elements must be direct imports.

Quick timings in one of my repos:

Before:

```bash
real 2m6.236s
user 2m11.438s
sys 0m3.328s
```

after:

```bash
real 0m13.535s
user 0m18.063s
sys 0m2.031s
```

Same number of errors and warnings came back in all the repos i tried.

cc @runem 