### PR TITLE
no-legacy-attribute rule

### DIFF
--- a/docs/readme/rules.md
+++ b/docs/readme/rules.md
@@ -21,6 +21,7 @@ Each rule can have severity of `off`, `warning` or `error`. You can toggle rules
 | [no-unknown-attribute](#-no-unknown-attribute-no-unknown-property)<br> [no-unknown-property](#-no-unknown-attribute-no-unknown-property) | You will get a warning whenever you use an unknown attribute or property within your `lit-html` template. | off | warning |
 | [no-unknown-event](#-no-unknown-event)       | When using event bindings it's checked that the event names are fired. | off | off |
 | [no-unknown-slot](#-no-unknown-slot)         | Using the "@slot" jsdoc tag on your custom element class, you can tell which slots are accepted for a particular element. | off | warning |
+| [no-legacy-attribute](#no-legacy-attribute)         | Disallows use of legacy Polymer binding syntax (e.g. `foo$=`). | off | warning |
 
 **Validating binding types**
 
@@ -194,6 +195,30 @@ html`
   <div slot="left"></div>
 </my-element>
 `
+```
+
+#### no-legacy-attribute
+
+A common mistake when dealing with Lit in particular is to use the
+legacy Polymer syntax as seen in earlier versions of Polymer (the
+predecessor of Lit).
+
+The following examples are considered warnings:
+
+<!-- prettier-ignore -->
+```js
+html`<input name$=${val} />`
+html`<input disabled?=${val} />`;
+html`<input name="{{val}}" />`;
+```
+
+The following examples are not considered warnings:
+
+<!-- prettier-ignore -->
+```js
+html`<input name=${val} />`
+html`<input ?disabled=${val} />`;
+html`<input name=${val} />`;
 ```
 
 ### Validating binding types

--- a/packages/lit-analyzer/src/analyze/default-lit-analyzer-context.ts
+++ b/packages/lit-analyzer/src/analyze/default-lit-analyzer-context.ts
@@ -19,6 +19,7 @@ import noUnknownTagName from "../rules/no-unknown-tag-name";
 import noUnknownAttribute from "../rules/no-unknown-attribute";
 import noUnknownProperty from "../rules/no-unknown-property";
 import noUnknownEvent from "../rules/no-unknown-event";
+import noLegacyAttribute from "../rules/no-legacy-attribute";
 import { RuleModule } from "./types/rule-module";
 import { isRuleDisabled, LitAnalyzerConfig, makeConfig } from "./lit-analyzer-config";
 import { LitAnalyzerContext, LitPluginContextHandler } from "./lit-analyzer-context";
@@ -47,7 +48,8 @@ const rules: RuleModule[] = [
 	noUnknownTagName,
 	noUnknownAttribute,
 	noUnknownProperty,
-	noUnknownEvent
+	noUnknownEvent,
+	noLegacyAttribute
 ];
 
 export class DefaultLitAnalyzerContext implements LitAnalyzerContext {

--- a/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
+++ b/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
@@ -22,7 +22,8 @@ export type LitAnalyzerRuleName =
 	| "no-unknown-property-converter"
 	| "no-invalid-attribute-name"
 	| "no-invalid-tag-name"
-	| "no-invalid-css";
+	| "no-invalid-css"
+	| "no-legacy-attribute";
 
 export const ALL_RULE_NAMES: LitAnalyzerRuleName[] = [
 	"no-unknown-tag-name",
@@ -45,7 +46,8 @@ export const ALL_RULE_NAMES: LitAnalyzerRuleName[] = [
 	"no-unknown-property-converter",
 	"no-invalid-attribute-name",
 	"no-invalid-tag-name",
-	"no-invalid-css"
+	"no-invalid-css",
+	"no-legacy-attribute"
 ];
 
 export type LitAnalyzerRuleSeverity = "off" | "warn" | "warning" | "error" | 0 | 1 | 2 | true | false;
@@ -73,7 +75,8 @@ const DEFAULT_RULES_NOSTRICT: Required<LitAnalyzerRules> = {
 	"no-unknown-property-converter": "error",
 	"no-invalid-attribute-name": "error",
 	"no-invalid-tag-name": "error",
-	"no-invalid-css": "warn"
+	"no-invalid-css": "warn",
+	"no-legacy-attribute": "off"
 };
 
 const DEFAULT_RULES_STRICT: Required<LitAnalyzerRules> = {
@@ -97,7 +100,8 @@ const DEFAULT_RULES_STRICT: Required<LitAnalyzerRules> = {
 	"no-unknown-property-converter": "error",
 	"no-invalid-attribute-name": "error",
 	"no-invalid-tag-name": "error",
-	"no-invalid-css": "error"
+	"no-invalid-css": "error",
+	"no-legacy-attribute": "off"
 };
 
 export function ruleSeverity(rules: LitAnalyzerConfig | LitAnalyzerRules, ruleName: LitAnalyzerRuleName): LitAnalyzerRuleSeverity {

--- a/packages/lit-analyzer/src/analyze/types/lit-diagnostic.ts
+++ b/packages/lit-analyzer/src/analyze/types/lit-diagnostic.ts
@@ -26,7 +26,8 @@ export enum LitHtmlDiagnosticKind {
 	INVALID_SLOT_NAME = "INVALID_SLOT_NAME",
 	MISSING_SLOT_ATTRIBUTE = "MISSING_SLOT_ATTRIBUTE",
 	DIRECTIVE_NOT_ALLOWED_HERE = "DIRECTIVE_NOT_ALLOWED_HERE",
-	INVALID_MIXED_BINDING = "INVALID_MIXED_BINDING"
+	INVALID_MIXED_BINDING = "INVALID_MIXED_BINDING",
+	LEGACY_SYNTAX = "LEGACY_SYNTAX"
 }
 
 export type LitDiagnosticSeverity = "error" | "warning";
@@ -155,6 +156,10 @@ export interface LitHtmlDiagnosticInvalidMixedBinding extends LitDocumentDiagnos
 	kind: LitHtmlDiagnosticKind.INVALID_MIXED_BINDING;
 }
 
+export interface LitHtmlDiagnosticLegacySyntax extends LitDocumentDiagnosticBase {
+	kind: LitHtmlDiagnosticKind.LEGACY_SYNTAX;
+}
+
 export type LitHtmlDiagnostic =
 	| LitHtmlDiagnosticUnknownTag
 	| LitHtmlDiagnosticMissingImport
@@ -173,7 +178,8 @@ export type LitHtmlDiagnostic =
 	| LitHtmlDiagnosticInvalidSlotName
 	| LitHtmlDiagnosticMissingSlotAttr
 	| LitHtmlDiagnosticInvalidMixedBinding
-	| LitHtmlDiagnosticTagNotClosed;
+	| LitHtmlDiagnosticTagNotClosed
+	| LitHtmlDiagnosticLegacySyntax;
 
 export interface LitCssDiagnostic extends LitDocumentDiagnosticBase {}
 

--- a/packages/lit-analyzer/src/rules/no-legacy-attribute.ts
+++ b/packages/lit-analyzer/src/rules/no-legacy-attribute.ts
@@ -1,0 +1,87 @@
+import { litDiagnosticRuleSeverity } from "../analyze/lit-analyzer-config";
+import { HtmlNodeAttrKind } from "../analyze/types/html-node/html-node-attr-types";
+import { HtmlNodeAttrAssignmentKind } from "../analyze/types/html-node/html-node-attr-assignment-types";
+import { HtmlNodeKind } from "../analyze/types/html-node/html-node-types";
+import { LitHtmlDiagnosticKind } from "../analyze/types/lit-diagnostic";
+import { RuleModule } from "../analyze/types/rule-module";
+import { suggestTargetForHtmlAttr } from "../analyze/util/attribute-util";
+
+const LEGACY_ASSIGNMENT = /^(\[\[[^\]]+\]\]|{{[^}]+}})/;
+
+/**
+ * This rule validates that legacy Polymer attribute bindings are not used.
+ */
+const rule: RuleModule = {
+	name: "no-legacy-attribute",
+	visitHtmlAttribute(htmlAttr, { htmlStore, config, definitionStore, document }) {
+		if (htmlAttr.htmlNode.kind !== HtmlNodeKind.NODE) {
+			return;
+		}
+
+		if (htmlAttr.kind !== HtmlNodeAttrKind.ATTRIBUTE && htmlAttr.kind !== HtmlNodeAttrKind.BOOLEAN_ATTRIBUTE) {
+			return;
+		}
+
+		const suggestedTarget = suggestTargetForHtmlAttr(htmlAttr, htmlStore);
+		const suggestedName = getSuggestedName(htmlAttr.name);
+
+		if (suggestedName !== htmlAttr.name) {
+			return [
+				{
+					kind: LitHtmlDiagnosticKind.LEGACY_SYNTAX,
+					message: `Legacy Polymer binding syntax in attribute '${htmlAttr.name}'.`,
+					fix: `Did you mean '${suggestedName}'?`,
+					location: { document, ...htmlAttr.location.name },
+					source: "no-legacy-attribute",
+					severity: litDiagnosticRuleSeverity(config, "no-legacy-attribute"),
+					suggestion: 'Legacy Polymer binding syntax is not supported in Lit.',
+					suggestedTarget
+				}
+			];
+		}
+
+		return;
+	},
+	visitHtmlAssignment(assignment, { htmlStore, config, definitionStore, document }) {
+		if (assignment.kind !== HtmlNodeAttrAssignmentKind.STRING) {
+			return;
+		}
+
+		const htmlAttr = assignment.htmlAttr;
+
+		if (LEGACY_ASSIGNMENT.test(assignment.value)) {
+			const suggestedTarget = suggestTargetForHtmlAttr(htmlAttr, htmlStore);
+
+			return [
+				{
+					kind: LitHtmlDiagnosticKind.LEGACY_SYNTAX,
+					message: `Legacy Polymer binding syntax in attribute '${htmlAttr.name}'.`,
+					location: { document, ...htmlAttr.location.name },
+					source: "no-legacy-attribute",
+					severity: litDiagnosticRuleSeverity(config, "no-legacy-attribute"),
+					suggestion: 'Legacy Polymer binding syntax is not supported in Lit.' +
+						' Instead you should use JavaScript interpolation, e.g. "attr=${foo}".',
+					suggestedTarget
+				}
+			];
+		}
+
+		return;
+	}
+};
+
+export default rule;
+
+/**
+ * Determines the non-legacy attribute name equivalent of the given name
+ * @param name legacy name
+ */
+function getSuggestedName(name: string): string {
+	if (name.endsWith('?')) {
+		return `?${name.slice(0, -1)}`;
+	}
+	if (name.endsWith('$')) {
+		return `${name.slice(0, -1)}`;
+	}
+	return name;
+}

--- a/packages/lit-analyzer/test/rules/no-legacy-attribute.ts
+++ b/packages/lit-analyzer/test/rules/no-legacy-attribute.ts
@@ -1,0 +1,28 @@
+import test from "ava";
+import { getDiagnostics } from "../helpers/analyze";
+import { hasDiagnostic, hasNoDiagnostics } from "../helpers/assert";
+
+test("Don't report legacy attributes when 'no-legacy-attribute' is turned off", t => {
+	const { diagnostics } = getDiagnostics("html`<input required?=${true} />`", { rules: { "no-legacy-attribute": false } });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+test("Report legacy attributes on known element", t => {
+	const { diagnostics } = getDiagnostics("html`<input required?=${true} />`", { rules: { "no-legacy-attribute": true } });
+	hasDiagnostic(t, diagnostics, "no-legacy-attribute");
+});
+
+test("Report legacy attribute values on known element", t => {
+	const { diagnostics } = getDiagnostics("html`<input value=\"{{foo}}\" />`", { rules: { "no-legacy-attribute": true } });
+	hasDiagnostic(t, diagnostics, "no-legacy-attribute");
+});
+
+test("Don't report non-legacy boolean attributes", t => {
+	const { diagnostics } = getDiagnostics("html`<input ?required=${true} />`", { rules: { "no-legacy-attribute": true } });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+test("Don't report non-legacy attributes", t => {
+	const { diagnostics } = getDiagnostics("html`<input required />`", { rules: { "no-legacy-attribute": true } });
+	hasNoDiagnostics(t, diagnostics);
+});


### PR DESCRIPTION
could this be a solution to #92 in a way?

i haven't added docs and finished it up just in case its not the kind of solution we're looking for.

it just detects legacy polymer binding syntax (`foo$=`, `foo?=`, `foo="[[bar]]"`, `foo="{{bar}}`).

cc @rictic @runem 