### PR TITLE
bump dependencies & simplify enabled rules logic

### DIFF
--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -43,8 +43,8 @@
 		"fast-glob": "^2.2.6",
 		"parse5": "5.1.0",
 		"ts-simple-type": "~0.3.6",
-		"vscode-css-languageservice": "4.0.2-next.1",
-		"vscode-html-languageservice": "2.1.12",
+		"vscode-css-languageservice": "4.1.2",
+		"vscode-html-languageservice": "3.0.3",
 		"web-component-analyzer": "~0.1.17"
 	},
 	"devDependencies": {
@@ -55,8 +55,8 @@
 		"rollup": "^1.27.12",
 		"rollup-plugin-node-resolve": "^5.2.0",
 		"rollup-plugin-replace": "^2.2.0",
-		"ts-node": "^8.5.4",
-		"tslib": "^1.10.0",
+		"ts-node": "^8.9.1",
+		"tslib": "^1.11.1",
 		"typescript": "^3.6.4"
 	},
 	"ava": {

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -51,7 +51,7 @@
 		"@appnest/readme": "^1.2.5",
 		"@types/node": "^12.12.17",
 		"@wessberg/rollup-plugin-ts": "^1.1.83",
-		"ava": "^2.4.0",
+		"ava": "^3.7.1",
 		"rollup": "^1.27.12",
 		"rollup-plugin-node-resolve": "^5.2.0",
 		"rollup-plugin-replace": "^2.2.0",
@@ -60,7 +60,6 @@
 		"typescript": "^3.6.4"
 	},
 	"ava": {
-		"compileEnhancements": false,
 		"extensions": [
 			"ts"
 		],
@@ -69,13 +68,8 @@
 		],
 		"snapshotDir": "test/snapshots/results",
 		"files": [
-			"test/**/*.ts"
-		],
-		"helpers": [
-			"test/helpers/**/*"
-		],
-		"sources": [
-			"src/**/*"
+			"test/**/*.ts",
+			"!test/helpers"
 		]
 	},
 	"contributors": [

--- a/packages/lit-analyzer/src/analyze/default-lit-analyzer-context.ts
+++ b/packages/lit-analyzer/src/analyze/default-lit-analyzer-context.ts
@@ -20,7 +20,7 @@ import noUnknownAttribute from "../rules/no-unknown-attribute";
 import noUnknownProperty from "../rules/no-unknown-property";
 import noUnknownEvent from "../rules/no-unknown-event";
 import { RuleModule } from "./types/rule-module";
-import { isRuleDisabled, LitAnalyzerConfig, makeConfig } from "./lit-analyzer-config";
+import { isRuleEnabled, isRuleDisabled, LitAnalyzerConfig, makeConfig } from "./lit-analyzer-config";
 import { LitAnalyzerContext, LitPluginContextHandler } from "./lit-analyzer-context";
 import { DefaultLitAnalyzerLogger, LitAnalyzerLoggerLevel } from "./lit-analyzer-logger";
 import { convertAnalyzeResultToHtmlCollection, convertComponentDeclarationToHtmlTag } from "./parse/convert-component-definitions-to-html-collection";
@@ -79,6 +79,10 @@ export class DefaultLitAnalyzerContext implements LitAnalyzerContext {
 
 	get rules(): RuleModule[] {
 		return rules;
+	}
+
+	get enabledRules(): RuleModule[] {
+		return this.rules.filter((rule) => isRuleEnabled(this.config, rule.name));
 	}
 
 	public updateConfig(config: LitAnalyzerConfig) {

--- a/packages/lit-analyzer/src/analyze/document-analyzer/html/diagnostic/validate-html-node-attr-assignment.ts
+++ b/packages/lit-analyzer/src/analyze/document-analyzer/html/diagnostic/validate-html-node-attr-assignment.ts
@@ -1,11 +1,10 @@
-import { isRuleEnabled } from "../../../lit-analyzer-config";
 import { LitAnalyzerRequest } from "../../../lit-analyzer-context";
 import { HtmlNodeAttrAssignment } from "../../../types/html-node/html-node-attr-assignment-types";
 import { LitHtmlDiagnostic } from "../../../types/lit-diagnostic";
 
 export function validateHtmlAttrAssignment(assignment: HtmlNodeAttrAssignment, request: LitAnalyzerRequest): LitHtmlDiagnostic[] {
-	for (const rule of request.rules) {
-		if (isRuleEnabled(request.config, rule.name) && rule.visitHtmlAssignment != null) {
+	for (const rule of request.enabledRules) {
+		if (rule.visitHtmlAssignment != null) {
 			const result = rule.visitHtmlAssignment(assignment, request);
 
 			if (result != null) {

--- a/packages/lit-analyzer/src/analyze/document-analyzer/html/diagnostic/validate-html-node-attr.ts
+++ b/packages/lit-analyzer/src/analyze/document-analyzer/html/diagnostic/validate-html-node-attr.ts
@@ -1,11 +1,10 @@
-import { isRuleEnabled } from "../../../lit-analyzer-config";
 import { LitAnalyzerRequest } from "../../../lit-analyzer-context";
 import { HtmlNodeAttr } from "../../../types/html-node/html-node-attr-types";
 import { LitHtmlDiagnostic } from "../../../types/lit-diagnostic";
 
 export function validateHtmlAttr(htmlAttr: HtmlNodeAttr, request: LitAnalyzerRequest): LitHtmlDiagnostic[] {
-	for (const rule of request.rules) {
-		if (isRuleEnabled(request.config, rule.name) && rule.visitHtmlAttribute != null) {
+	for (const rule of request.enabledRules) {
+		if (rule.visitHtmlAttribute != null) {
 			const result = rule.visitHtmlAttribute(htmlAttr, request);
 
 			if (result != null) {

--- a/packages/lit-analyzer/src/analyze/document-analyzer/html/diagnostic/validate-html-node.ts
+++ b/packages/lit-analyzer/src/analyze/document-analyzer/html/diagnostic/validate-html-node.ts
@@ -1,11 +1,10 @@
-import { isRuleEnabled } from "../../../lit-analyzer-config";
 import { LitAnalyzerRequest } from "../../../lit-analyzer-context";
 import { HtmlNode } from "../../../types/html-node/html-node-types";
 import { LitHtmlDiagnostic } from "../../../types/lit-diagnostic";
 
 export function validateHtmlNode(htmlNode: HtmlNode, request: LitAnalyzerRequest): LitHtmlDiagnostic[] {
-	for (const rule of request.rules) {
-		if (isRuleEnabled(request.config, rule.name) && rule.visitHtmlNode != null) {
+	for (const rule of request.enabledRules) {
+		if (rule.visitHtmlNode != null) {
 			const result = rule.visitHtmlNode(htmlNode, request);
 
 			if (result != null) {

--- a/packages/lit-analyzer/src/analyze/lit-analyzer-context.ts
+++ b/packages/lit-analyzer/src/analyze/lit-analyzer-context.ts
@@ -21,6 +21,7 @@ export interface LitAnalyzerContext {
 	readonly definitionStore: AnalyzerDefinitionStore;
 	readonly logger: LitAnalyzerLogger;
 	readonly rules: RuleModule[];
+	readonly enabledRules: RuleModule[];
 	updateConfig(config: LitAnalyzerConfig): void;
 	updateDependencies(file: SourceFile): void;
 	updateComponents(file: SourceFile): void;

--- a/packages/lit-analyzer/src/analyze/lit-analyzer.ts
+++ b/packages/lit-analyzer/src/analyze/lit-analyzer.ts
@@ -304,7 +304,8 @@ export class LitAnalyzer {
 			documentStore,
 			logger,
 			updateConfig,
-			rules
+			rules,
+			enabledRules
 		} = this.context;
 
 		return {
@@ -321,6 +322,7 @@ export class LitAnalyzer {
 			logger,
 			updateConfig,
 			rules,
+			enabledRules,
 			...options
 		};
 	}


### PR DESCRIPTION
do it only in one place and bump some deps.

seems to work fine, let me know if anything looks off.

typescript can't be updated until WCA has the same version bump.

edit: no clue why ci fails, exact same stuff passes locally with a clean  repo (git clean -xdf)