### PR TITLE
rule: property visibility mismatch

### DIFF
--- a/docs/readme/rules.md
+++ b/docs/readme/rules.md
@@ -500,6 +500,25 @@ class MyElement extends LitElement {
 customElements.define("correct-element-name", MyElement);
 ```
 
+#### no-property-visibility-mismatch
+
+When using the `@property` decorator, your property should be publicly visible,
+expected to be exposed to consumers of the element. Private and protected
+properties however, should make use of the `@internalProperty` decorator
+instead.
+
+This rule will ensure public properties use `@property` and non-public
+properties use `@internalProperty`.
+
+The following example is considered a warning:
+
+<!-- prettier-ignore -->
+```ts
+class MyElement extends LitElement {
+	@property() private myProperty: string;
+}
+```
+
 ### Validating CSS
 
 `lit-analyzer` uses [vscode-css-languageservice](https://github.com/Microsoft/vscode-css-languageservice) to validate CSS.

--- a/packages/lit-analyzer/src/analyze/default-lit-analyzer-context.ts
+++ b/packages/lit-analyzer/src/analyze/default-lit-analyzer-context.ts
@@ -20,6 +20,7 @@ import noUnknownEvent from "../rules/no-unknown-event";
 import noUnknownProperty from "../rules/no-unknown-property";
 import noUnknownSlotRule from "../rules/no-unknown-slot";
 import noUnknownTagName from "../rules/no-unknown-tag-name";
+import noPropertyVisibilityMismatch from "../rules/no-property-visibility-mismatch";
 import { getBuiltInHtmlCollection } from "./data/get-built-in-html-collection";
 import { getUserConfigHtmlCollection } from "./data/get-user-config-html-collection";
 import { isRuleDisabled, LitAnalyzerConfig, makeConfig } from "./lit-analyzer-config";
@@ -55,7 +56,8 @@ const ALL_RULES: RuleModule[] = [
 	noUnknownEvent,
 	noIncompatiblePropertyType,
 	noInvalidTagName,
-	noInvalidAttributeName
+	noInvalidAttributeName,
+	noPropertyVisibilityMismatch
 ];
 
 export class DefaultLitAnalyzerContext implements LitAnalyzerContext {

--- a/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
+++ b/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
@@ -21,7 +21,8 @@ export type LitAnalyzerRuleId =
 	| "no-incompatible-property-type"
 	| "no-invalid-attribute-name"
 	| "no-invalid-tag-name"
-	| "no-invalid-css";
+	| "no-invalid-css"
+	| "no-property-visibility-mismatch";
 
 export const ALL_RULE_NAMES: LitAnalyzerRuleId[] = [
 	"no-unknown-tag-name",
@@ -43,7 +44,8 @@ export const ALL_RULE_NAMES: LitAnalyzerRuleId[] = [
 	"no-incompatible-property-type",
 	"no-invalid-attribute-name",
 	"no-invalid-tag-name",
-	"no-invalid-css"
+	"no-invalid-css",
+	"no-property-visibility-mismatch"
 ];
 
 export type LitAnalyzerRuleSeverity = "off" | "warn" | "warning" | "error" | 0 | 1 | 2 | true | false;
@@ -70,7 +72,8 @@ const DEFAULT_RULES_NOSTRICT: Required<LitAnalyzerRules> = {
 	"no-incompatible-property-type": "error",
 	"no-invalid-attribute-name": "error",
 	"no-invalid-tag-name": "error",
-	"no-invalid-css": "warn"
+	"no-invalid-css": "warn",
+	"no-property-visibility-mismatch": "off"
 };
 
 const DEFAULT_RULES_STRICT: Required<LitAnalyzerRules> = {
@@ -93,7 +96,8 @@ const DEFAULT_RULES_STRICT: Required<LitAnalyzerRules> = {
 	"no-incompatible-property-type": "error",
 	"no-invalid-attribute-name": "error",
 	"no-invalid-tag-name": "error",
-	"no-invalid-css": "error"
+	"no-invalid-css": "error",
+	"no-property-visibility-mismatch": "error"
 };
 
 export function ruleSeverity(rules: LitAnalyzerConfig | LitAnalyzerRules, ruleId: LitAnalyzerRuleId): LitAnalyzerRuleSeverity {

--- a/packages/lit-analyzer/src/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/rules/no-property-visibility-mismatch.ts
@@ -4,12 +4,12 @@ import { RuleModule } from "../analyze/types/rule/rule-module";
 import { rangeFromNode } from "../analyze/util/range-util";
 
 const isInternalProperty = (member: ComponentMember): boolean => {
-  return member.kind === "property" &&
-    ts.isPropertyDeclaration(member.node) &&
-    member.node.decorators?.some((d) =>
-      ts.isCallExpression(d.expression) &&
-      ts.isIdentifier(d.expression.expression) &&
-      d.expression.expression.text === "internalProperty") === true;
+	return member.kind === "property" &&
+		ts.isPropertyDeclaration(member.node) &&
+		member.node.decorators?.some((d) =>
+			ts.isCallExpression(d.expression) &&
+			ts.isIdentifier(d.expression.expression) &&
+			d.expression.expression.text === "internalProperty") === true;
 };
 
 /**

--- a/packages/lit-analyzer/src/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/rules/no-property-visibility-mismatch.ts
@@ -5,11 +5,10 @@ import { RuleModuleContext } from "../analyze/types/rule/rule-module-context";
 
 const isInternalProperty = (context: RuleModuleContext, member: ComponentMember): boolean => {
 	return member.kind === "property" &&
-		context.ts.isPropertyDeclaration(member.node) &&
-		member.node.decorators?.some((d) =>
-			context.ts.isCallExpression(d.expression) &&
-			context.ts.isIdentifier(d.expression.expression) &&
-			d.expression.expression.escapedText === "internalProperty") === true;
+		member.meta?.node?.decorator !== undefined &&
+		context.ts.isCallExpression(member.meta.node.decorator) &&
+		context.ts.isIdentifier(member.meta.node.decorator.expression) &&
+		member.meta.node.decorator.expression.text === "internalProperty";
 };
 
 /**

--- a/packages/lit-analyzer/src/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/rules/no-property-visibility-mismatch.ts
@@ -1,9 +1,15 @@
+import * as ts from "typescript";
 import { ComponentMember } from "web-component-analyzer";
 import { RuleModule } from "../analyze/types/rule/rule-module";
 import { rangeFromNode } from "../analyze/util/range-util";
 
 const isInternalProperty = (member: ComponentMember): boolean => {
-	return member.kind === "property" && member.meta?.attribute === false;
+  return member.kind === "property" &&
+    ts.isPropertyDeclaration(member.node) &&
+    member.node.decorators?.some((d) =>
+      ts.isCallExpression(d.expression) &&
+      ts.isIdentifier(d.expression.expression) &&
+      d.expression.expression.text === "internalProperty") === true;
 };
 
 /**

--- a/packages/lit-analyzer/src/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/rules/no-property-visibility-mismatch.ts
@@ -1,15 +1,15 @@
-import * as ts from "typescript";
 import { ComponentMember } from "web-component-analyzer";
 import { RuleModule } from "../analyze/types/rule/rule-module";
 import { rangeFromNode } from "../analyze/util/range-util";
+import { RuleModuleContext } from "../analyze/types/rule/rule-module-context";
 
-const isInternalProperty = (member: ComponentMember): boolean => {
+const isInternalProperty = (context: RuleModuleContext, member: ComponentMember): boolean => {
 	return member.kind === "property" &&
-		ts.isPropertyDeclaration(member.node) &&
+		context.ts.isPropertyDeclaration(member.node) &&
 		member.node.decorators?.some((d) =>
-			ts.isCallExpression(d.expression) &&
-			ts.isIdentifier(d.expression.expression) &&
-			d.expression.expression.text === "internalProperty") === true;
+			context.ts.isCallExpression(d.expression) &&
+			context.ts.isIdentifier(d.expression.expression) &&
+			d.expression.expression.escapedText === "internalProperty") === true;
 };
 
 /**
@@ -23,7 +23,7 @@ const rule: RuleModule = {
 	},
 	visitComponentMember(member, context) {
 		if (member.kind === "property") {
-			const isInternal = isInternalProperty(member);
+			const isInternal = isInternalProperty(context, member);
 
 			if (isInternal && member.visibility === "public") {
 				context.report({

--- a/packages/lit-analyzer/src/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/rules/no-property-visibility-mismatch.ts
@@ -1,0 +1,41 @@
+import { ComponentMember } from "web-component-analyzer";
+import { RuleModule } from "../analyze/types/rule/rule-module";
+import { rangeFromNode } from "../analyze/util/range-util";
+
+const isInternalProperty = (member: ComponentMember): boolean => {
+	return member.kind === 'property' && member.meta?.attribute === false;
+}
+
+/**
+ * This rule detects mismatches with property visibilities and the decorators
+	* they were defined with.
+ */
+const rule: RuleModule = {
+	id: "no-property-visibility-mismatch",
+	meta: {
+		priority: "low"
+	},
+	visitComponentMember(member, context) {
+		if (member.kind === "property") {
+			const isInternal = isInternalProperty(member);
+
+			if (isInternal && member.visibility === 'public') {
+				context.report({
+					location: rangeFromNode(member.node),
+					message: `'${member.propName}' is marked as an internal property (@internalProperty) but is publicly visible.`,
+					suggestion: "Change the property visibility to 'private' or 'protected'."
+				});
+			}
+
+			if (!isInternal && member.visibility !== 'public') {
+				context.report({
+					location: rangeFromNode(member.node),
+					message: `'${member.propName}' is not publicy visible but is not marked as an internal property (@internalProperty).`,
+					suggestion: "Add the '@internalProperty' decorator instead of '@property'."
+				});
+			}
+		}
+	}
+};
+
+export default rule;

--- a/packages/lit-analyzer/src/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/rules/no-property-visibility-mismatch.ts
@@ -3,12 +3,12 @@ import { RuleModule } from "../analyze/types/rule/rule-module";
 import { rangeFromNode } from "../analyze/util/range-util";
 
 const isInternalProperty = (member: ComponentMember): boolean => {
-	return member.kind === 'property' && member.meta?.attribute === false;
-}
+	return member.kind === "property" && member.meta?.attribute === false;
+};
 
 /**
  * This rule detects mismatches with property visibilities and the decorators
-	* they were defined with.
+ * they were defined with.
  */
 const rule: RuleModule = {
 	id: "no-property-visibility-mismatch",
@@ -19,7 +19,7 @@ const rule: RuleModule = {
 		if (member.kind === "property") {
 			const isInternal = isInternalProperty(member);
 
-			if (isInternal && member.visibility === 'public') {
+			if (isInternal && member.visibility === "public") {
 				context.report({
 					location: rangeFromNode(member.node),
 					message: `'${member.propName}' is marked as an internal property (@internalProperty) but is publicly visible.`,
@@ -27,7 +27,7 @@ const rule: RuleModule = {
 				});
 			}
 
-			if (!isInternal && member.visibility !== 'public') {
+			if (!isInternal && member.visibility !== "public") {
 				context.report({
 					location: rangeFromNode(member.node),
 					message: `'${member.propName}' is not publicy visible but is not marked as an internal property (@internalProperty).`,

--- a/packages/lit-analyzer/test/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/test/rules/no-property-visibility-mismatch.ts
@@ -1,0 +1,49 @@
+import { getDiagnostics } from "../helpers/analyze";
+import { hasDiagnostic, hasNoDiagnostics } from "../helpers/assert";
+import { tsTest } from "../helpers/ts-test";
+import { TestFile } from "../helpers/compile-files";
+
+function makeTestElement({ properties }: { properties?: Array<{ visibility: string; name: string; internal: boolean; }>; }): TestFile {
+	return {
+		fileName: "my-element.ts",
+		text: `
+		class MyElement extends HTMElement {
+			${(properties || []).map(({ name, visibility, internal }) => `@${internal ? "internalProperty" : "property"}() ${visibility} ${name}`).join("\n")}
+		};
+		customElements.define("my-element", MyElement);	
+		`
+	};
+}
+
+tsTest("Report public @internalProperty properties", t => {
+	const { diagnostics } = getDiagnostics(makeTestElement({
+			properties: [
+				{ name: 'foo', visibility: 'public', internal: true }
+			]
+	}), {
+		rules: { "no-property-visibility-mismatch": true }
+	});
+	hasDiagnostic(t, diagnostics, "no-property-visibility-mismatch");
+});
+
+tsTest("Report private @property properties", t => {
+	const { diagnostics } = getDiagnostics(makeTestElement({
+			properties: [
+				{ name: 'foo', visibility: 'private', internal: false }
+			]
+	}), {
+		rules: { "no-property-visibility-mismatch": true }
+	});
+	hasDiagnostic(t, diagnostics, "no-property-visibility-mismatch");
+});
+
+tsTest("Don't report regular public properties", t => {
+	const { diagnostics } = getDiagnostics(makeTestElement({
+			properties: [
+				{ name: 'foo', visibility: 'public', internal: false }
+			]
+	}), {
+		rules: { "no-property-visibility-mismatch": true }
+	});
+	hasNoDiagnostics(t, diagnostics);
+});

--- a/packages/lit-analyzer/test/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/test/rules/no-property-visibility-mismatch.ts
@@ -3,7 +3,7 @@ import { hasDiagnostic, hasNoDiagnostics } from "../helpers/assert";
 import { tsTest } from "../helpers/ts-test";
 import { TestFile } from "../helpers/compile-files";
 
-function makeTestElement({ properties }: { properties?: Array<{ visibility: string; name: string; internal: boolean; }>; }): TestFile {
+function makeTestElement({ properties }: { properties?: Array<{ visibility: string; name: string; internal: boolean }> }): TestFile {
 	return {
 		fileName: "my-element.ts",
 		text: `
@@ -16,34 +16,37 @@ function makeTestElement({ properties }: { properties?: Array<{ visibility: stri
 }
 
 tsTest("Report public @internalProperty properties", t => {
-	const { diagnostics } = getDiagnostics(makeTestElement({
-			properties: [
-				{ name: 'foo', visibility: 'public', internal: true }
-			]
-	}), {
-		rules: { "no-property-visibility-mismatch": true }
-	});
+	const { diagnostics } = getDiagnostics(
+		makeTestElement({
+			properties: [{ name: "foo", visibility: "public", internal: true }]
+		}),
+		{
+			rules: { "no-property-visibility-mismatch": true }
+		}
+	);
 	hasDiagnostic(t, diagnostics, "no-property-visibility-mismatch");
 });
 
 tsTest("Report private @property properties", t => {
-	const { diagnostics } = getDiagnostics(makeTestElement({
-			properties: [
-				{ name: 'foo', visibility: 'private', internal: false }
-			]
-	}), {
-		rules: { "no-property-visibility-mismatch": true }
-	});
+	const { diagnostics } = getDiagnostics(
+		makeTestElement({
+			properties: [{ name: "foo", visibility: "private", internal: false }]
+		}),
+		{
+			rules: { "no-property-visibility-mismatch": true }
+		}
+	);
 	hasDiagnostic(t, diagnostics, "no-property-visibility-mismatch");
 });
 
 tsTest("Don't report regular public properties", t => {
-	const { diagnostics } = getDiagnostics(makeTestElement({
-			properties: [
-				{ name: 'foo', visibility: 'public', internal: false }
-			]
-	}), {
-		rules: { "no-property-visibility-mismatch": true }
-	});
+	const { diagnostics } = getDiagnostics(
+		makeTestElement({
+			properties: [{ name: "foo", visibility: "public", internal: false }]
+		}),
+		{
+			rules: { "no-property-visibility-mismatch": true }
+		}
+	);
 	hasNoDiagnostics(t, diagnostics);
 });

--- a/packages/lit-analyzer/test/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/test/rules/no-property-visibility-mismatch.ts
@@ -10,7 +10,7 @@ function makeTestElement({ properties }: { properties?: Array<{ visibility: stri
 		class MyElement extends HTMElement {
 			${(properties || []).map(({ name, visibility, internal }) => `@${internal ? "internalProperty" : "property"}() ${visibility} ${name}`).join("\n")}
 		};
-		customElements.define("my-element", MyElement);	
+		customElements.define("my-element", MyElement);
 		`
 	};
 }

--- a/packages/lit-analyzer/test/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/test/rules/no-property-visibility-mismatch.ts
@@ -8,7 +8,7 @@ function makeTestElement({ properties }: { properties?: Array<{ visibility: stri
 		fileName: "my-element.ts",
 		text: `
 		class MyElement extends HTMElement {
-			${(properties || []).map(({ name, visibility, internal }) => `@${internal ? "internalProperty" : "property"}() ${visibility} ${name}`).join("\n")}
+			${(properties || []).map(({ name, visibility, internal }) => `@${internal ? "internalProperty" : "property"}() ${visibility} ${name}: any;`).join("\n")}
 		};
 		customElements.define("my-element", MyElement);
 		`


### PR DESCRIPTION
this tries to do something along the lines of what #79 wanted i guess.

this bit is _questionable_:

```ts
	return member.kind === 'property' && member.meta?.attribute === false;
```

to detect if `@internalProperty` was used. it is upto you if you want to introduce something in WCA so component members have an explicit flag when they use that decorator. this should work fine though since making a property not use attributes is close enough to being internal anyway.