### PR TITLE
Add "autocapitalize" global attribute

### DIFF
--- a/packages/lit-analyzer/src/analyze/data/extra-html-data.ts
+++ b/packages/lit-analyzer/src/analyze/data/extra-html-data.ts
@@ -40,6 +40,7 @@ const HTML_5_ATTR_TYPES: { [key: string]: string | string[] } = {
 	"aria-valuenow": "",
 	"aria-valuetext": "",
 	accesskey: "string",
+	autocapitalize: ["off", "none", "on", "sentences", "words", "characters"],
 	class: "string",
 	contextmenu: "string",
 	dropzone: ["copy", "move", "link"],


### PR DESCRIPTION
Add the global attribute [autocapitalize](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize), which has possible values of `off`, `none`, `on`, `sentences`, `words`, and `characters`