### PR TITLE
fix quickfix for 'no-missing-import' on windows.

### DIFF
--- a/packages/lit-analyzer/src/rules/no-missing-import.ts
+++ b/packages/lit-analyzer/src/rules/no-missing-import.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, relative } from "path";
+import { basename, dirname, posix } from "path";
 import { RuleModule } from "../analyze/types/rule/rule-module";
 import { isCustomElementTagName } from "../analyze/util/is-valid-name";
 import { rangeFromHtmlNode } from "../analyze/util/range-util";
@@ -64,7 +64,7 @@ export default rule;
  * @param toFileName
  */
 function getRelativePathForImport(fromFileName: string, toFileName: string): string {
-	const path = relative(dirname(fromFileName), dirname(toFileName));
+	const path = posix.relative(dirname(fromFileName), dirname(toFileName));
 	const filenameWithoutExt = basename(toFileName).replace(/\.[^/.]+$/, "");
 	const importPath = `./${path ? `${path}/` : ""}${filenameWithoutExt}`;
 	return importPath

--- a/packages/lit-analyzer/test/helpers/analyze.ts
+++ b/packages/lit-analyzer/test/helpers/analyze.ts
@@ -6,6 +6,8 @@ import { LitAnalyzerContext } from "../../src/analyze/lit-analyzer-context";
 import { LitDiagnostic } from "../../src/analyze/types/lit-diagnostic";
 import { compileFiles, TestFile } from "./compile-files";
 import { getCurrentTsModule } from "./ts-test";
+import { Range } from "../../src/analyze/types/range";
+import { LitCodeFix } from "../../src/analyze/types/lit-code-fix";
 
 /**
  * Prepares both the Typescript program and the LitAnalyzer
@@ -50,6 +52,25 @@ export function getDiagnostics(
 
 	return {
 		diagnostics: analyzer.getDiagnosticsInFile(sourceFile),
+		program,
+		sourceFile
+	};
+}
+
+/**
+ * Returns code fixes in 'virtual' files using the LitAnalyzer
+ * @param inputFiles
+ * @param config
+ */
+export function getCodeFixesAtRange(
+	inputFiles: TestFile[] | TestFile,
+	range: Range,
+	config: Partial<LitAnalyzerConfig> = {}
+): { codeFixes: LitCodeFix[]; program: Program; sourceFile: SourceFile } {
+	const { analyzer, sourceFile, program } = prepareAnalyzer(inputFiles, config);
+
+	return {
+		codeFixes: analyzer.getCodeFixesAtPositionRange(sourceFile, range),
 		program,
 		sourceFile
 	};

--- a/packages/lit-analyzer/test/helpers/compile-files.ts
+++ b/packages/lit-analyzer/test/helpers/compile-files.ts
@@ -79,7 +79,7 @@ export function compileFiles(inputFiles: TestFile[] | TestFile = []): { program:
 		},
 
 		getCurrentDirectory() {
-			return ".";
+			return "./";
 		},
 
 		getDirectories(directoryName: string) {

--- a/packages/lit-analyzer/test/helpers/generate-test-file.ts
+++ b/packages/lit-analyzer/test/helpers/generate-test-file.ts
@@ -7,7 +7,7 @@ export function makeElement({ properties, slots }: { properties?: string[]; slot
 		/**
 ${(slots || []).map(slot => `        * @slot ${slot}`)}
 		 */
-		class MyElement extends HTMElement {
+		class MyElement extends HTMLElement {
 			${(properties || []).map(prop => `@property() ${prop}`).join("\n")}
 		};
 		customElements.define("my-element", MyElement);	

--- a/packages/lit-analyzer/test/rules/no-missing-import.ts
+++ b/packages/lit-analyzer/test/rules/no-missing-import.ts
@@ -1,4 +1,4 @@
-import { getDiagnostics } from "../helpers/analyze";
+import { getDiagnostics, getCodeFixesAtRange } from "../helpers/analyze";
 import { hasDiagnostic, hasNoDiagnostics } from "../helpers/assert";
 import { makeElement } from "../helpers/generate-test-file";
 import { tsTest } from "../helpers/ts-test";
@@ -28,4 +28,28 @@ tsTest("Don't report missing imports when the custom element has been imported 2
 		{ rules: { "no-missing-import": true } }
 	);
 	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("Suggest adding correct import statement", t => {
+	const fileContentWithMissingImport = "html`<my-element></my-element>`";
+	const elementTagWithoutImport = "my-element";
+
+	// the range has to point to the name of an element. In this case it is 6 to 15.
+	// html`<my-element></my-element>`
+	// 0123456789012345678901234567891
+	//       |--------|
+	//       my-element
+	const start = fileContentWithMissingImport.indexOf(elementTagWithoutImport);
+	const end = start + elementTagWithoutImport.length - 1;
+
+	const { codeFixes } = getCodeFixesAtRange(
+		[makeElement({}), fileContentWithMissingImport],
+		{ start, end },
+		{ rules: { "no-missing-import": true } }
+	);
+	const correctCodeFixCreated = codeFixes.some(litCodeFix =>
+		litCodeFix.actions.some(litCodeFixAction => litCodeFixAction.newText === '\nimport "./my-element";')
+	);
+
+	t.true(correctCodeFixCreated);
 });

--- a/packages/lit-analyzer/test/rules/no-missing-import.ts
+++ b/packages/lit-analyzer/test/rules/no-missing-import.ts
@@ -2,6 +2,7 @@ import { getDiagnostics, getCodeFixesAtRange } from "../helpers/analyze";
 import { hasDiagnostic, hasNoDiagnostics } from "../helpers/assert";
 import { makeElement } from "../helpers/generate-test-file";
 import { tsTest } from "../helpers/ts-test";
+import { TestFile } from "../helpers/compile-files";
 
 tsTest("Report missing imports of custom elements", t => {
 	const { diagnostics } = getDiagnostics([makeElement({}), "html`<my-element></my-element>`"], { rules: { "no-missing-import": true } });
@@ -49,6 +50,34 @@ tsTest("Suggest adding correct import statement", t => {
 	);
 	const correctCodeFixCreated = codeFixes.some(litCodeFix =>
 		litCodeFix.actions.some(litCodeFixAction => litCodeFixAction.newText === '\nimport "./my-element";')
+	);
+
+	t.true(correctCodeFixCreated);
+});
+
+tsTest("Suggest adding correct import statement for element in nested folder", t => {
+	const fileContentWithMissingImport = "html`<my-element></my-element>`";
+	const elementTagWithoutImport = "my-element";
+
+	// the range has to point to the name of an element. In this case it is 6 to 15.
+	// html`<my-element></my-element>`
+	// 0123456789012345678901234567891
+	//       |--------|
+	//       my-element
+	const start = fileContentWithMissingImport.indexOf(elementTagWithoutImport);
+	const end = start + elementTagWithoutImport.length - 1;
+	const nestedElement: TestFile = {
+		fileName: "1/2/3/4/5/my-element.ts",
+		text: `
+		class MyElement extends HTMLElement {
+		};
+		customElements.define("my-element", MyElement);	
+		`
+	};
+	const { codeFixes } = getCodeFixesAtRange([nestedElement, fileContentWithMissingImport], { start, end }, { rules: { "no-missing-import": true } });
+
+	const correctCodeFixCreated = codeFixes.some(litCodeFix =>
+		litCodeFix.actions.some(litCodeFixAction => litCodeFixAction.newText === '\nimport "./1/2/3/4/5/my-element";')
 	);
 
 	t.true(correctCodeFixCreated);


### PR DESCRIPTION
On windows, the quickfixes suggested by the "no-missing-import" rule generate broken paths when dealing with nested folders.

In a project with a structure like this:
```bash
parent.ts
children
  └─1
    └─folder
      └─another-folder
          child1.ts
```

When you generate an import for child1.ts inside of parent.ts your get this statement:
> import "./children\1\folder\another-folder/child1";

This doesnt work since imports require UNIX-like file paths with forward slashes.

This PR fixes the bug.
The generated import statement now looks like this:
> import "./children/1/folder/another-folder/child1";
