### PR TITLE
Fix location where imports are inserted.

### DIFF
--- a/packages/lit-analyzer/src/analyze/util/rule-fix-util.ts
+++ b/packages/lit-analyzer/src/analyze/util/rule-fix-util.ts
@@ -142,7 +142,7 @@ function getLastImportIndex(sourceFile: SourceFile): number {
 	let lastImportIndex = 0;
 
 	for (const statement of sourceFile.statements) {
-		if (tsModule.ts.isImportDeclaration(statement) || tsModule.ts.isImportEqualsDeclaration(statement)) {
+		if (tsModule.ts.isImportDeclaration(statement)) {
 			lastImportIndex = statement.getEnd();
 		}
 	}

--- a/packages/lit-analyzer/src/analyze/util/rule-fix-util.ts
+++ b/packages/lit-analyzer/src/analyze/util/rule-fix-util.ts
@@ -105,7 +105,7 @@ function ruleFixActionConverter(action: RuleFixAction): LitCodeFixAction[] {
 				{
 					range: makeSourceFileRange({
 						start: lastImportIndex,
-						end: 0
+						end: lastImportIndex
 					}),
 					newText: `\nimport "${action.path}";`
 				}
@@ -142,7 +142,7 @@ function getLastImportIndex(sourceFile: SourceFile): number {
 	let lastImportIndex = 0;
 
 	for (const statement of sourceFile.statements) {
-		if (tsModule.ts.isImportDeclaration(statement)) {
+		if (tsModule.ts.isImportDeclaration(statement) || tsModule.ts.isImportEqualsDeclaration(statement)) {
 			lastImportIndex = statement.getEnd();
 		}
 	}


### PR DESCRIPTION
When using the codefix suggested by the "no-missing-import" rule, the import statement currently gets inserted on line one. In some cases it even overwrites existing import statements.

This is likely a mistake from the refactoring that was done on the 1.2.0 branch.
[This code](https://github.com/runem/lit-analyzer/blob/master/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-code-fixes.ts#L38) was wrongly refactored into [this](https://github.com/runem/lit-analyzer/blob/1.2.0/packages/lit-analyzer/src/analyze/util/rule-fix-util.ts#L107-L108).

Notice how the setting changed from span to range but the parameters stayed the same.