### PR TITLE
Implement function to detect facade modules; Adjust depth check in dependency traversal.

### DIFF
--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
@@ -4,7 +4,7 @@ import { LitAnalyzerContext } from "../../lit-analyzer-context";
 import { visitIndirectImportsFromSourceFile } from "./visit-dependencies";
 
 // Depth constants
-const MAX_EXTERNAL_DEPTH = 2;
+const MAX_EXTERNAL_DEPTH = 1;
 
 const MAX_INTERNAL_DEPTH = Infinity;
 

--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
@@ -4,7 +4,7 @@ import { LitAnalyzerContext } from "../../lit-analyzer-context";
 import { visitIndirectImportsFromSourceFile } from "./visit-dependencies";
 
 // Depth constants
-const MAX_EXTERNAL_DEPTH = 1;
+const MAX_EXTERNAL_DEPTH = 2;
 
 const MAX_INTERNAL_DEPTH = Infinity;
 

--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
@@ -64,8 +64,14 @@ export function parseDependencies(sourceFile: SourceFile, context: LitAnalyzerCo
  * Returns a map of component declarations in each file encountered from a source file recursively.
  * @param sourceFile
  * @param context
+ * @param maxExternalDepth
+ * @param minExternalDepth
  */
-export function parseAllIndirectImports(sourceFile: SourceFile, context: LitAnalyzerContext): Set<SourceFile> {
+export function parseAllIndirectImports(
+	sourceFile: SourceFile,
+	context: LitAnalyzerContext,
+	{ maxExternalDepth, maxInternalDepth }: { maxExternalDepth?: number; maxInternalDepth?: number } = {}
+): Set<SourceFile> {
 	const importedSourceFiles = new Set<SourceFile>();
 
 	visitIndirectImportsFromSourceFile(sourceFile, {
@@ -73,8 +79,8 @@ export function parseAllIndirectImports(sourceFile: SourceFile, context: LitAnal
 		program: context.program,
 		ts: context.ts,
 		directImportCache: DIRECT_IMPORT_CACHE,
-		maxExternalDepth: MAX_EXTERNAL_DEPTH,
-		maxInternalDepth: MAX_INTERNAL_DEPTH,
+		maxExternalDepth: maxExternalDepth ?? MAX_EXTERNAL_DEPTH,
+		maxInternalDepth: maxInternalDepth ?? MAX_INTERNAL_DEPTH,
 		emitIndirectImport(file: SourceFile): boolean {
 			if (importedSourceFiles.has(file)) {
 				return false;

--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -31,9 +31,9 @@ export function visitIndirectImportsFromSourceFile(sourceFile: SourceFile, conte
 
 	// Check if we have traversed too deep
 	// Subtract 1 because depth starts at 0
-	if (inExternal && currentDepth >= (context.maxExternalDepth ?? Infinity) - 1) {
+	if (inExternal && currentDepth > (context.maxExternalDepth ?? Infinity) - 1) {
 		return;
-	} else if (!inExternal && currentDepth >= (context.maxInternalDepth ?? Infinity) - 1) {
+	} else if (!inExternal && currentDepth > (context.maxInternalDepth ?? Infinity) - 1) {
 		return;
 	}
 
@@ -70,7 +70,15 @@ export function visitIndirectImportsFromSourceFile(sourceFile: SourceFile, conte
 
 		// Calculate new depth. Reset depth to 0 if we go from a project module to an external module.
 		// This will make sure that we always go X modules deep into external modules
-		const newDepth = fromProjectToExternal ? 0 : currentDepth + 1;
+		let newDepth;
+		if (fromProjectToExternal) {
+			newDepth = 0;
+		} else if (isFacadeModule(file, context.ts)) {
+			// Facade modules are ignored when calculating depth
+			newDepth = currentDepth;
+		} else {
+			newDepth = currentDepth + 1;
+		}
 
 		// Visit direct imported source files recursively
 		visitIndirectImportsFromSourceFile(file, {
@@ -140,4 +148,18 @@ function emitDirectModuleImportWithName(moduleSpecifier: string, node: Node, con
 			context.emitDirectImport?.(sourceFile);
 		}
 	}
+}
+
+/**
+ * Returns whether a SourceFile is a Facade Module.
+ * A Facade Module only consists of import and export declarations.
+ * @param SourceFile
+ * @param TsModule
+ */
+function isFacadeModule(SourceFile: SourceFile, TsModule: typeof tsModule): boolean {
+	const statements = SourceFile.statements;
+	const isFacade = statements.every(statement => {
+		return TsModule.isImportDeclaration(statement) || TsModule.isExportDeclaration(statement);
+	});
+	return isFacade;
 }

--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -31,9 +31,9 @@ export function visitIndirectImportsFromSourceFile(sourceFile: SourceFile, conte
 
 	// Check if we have traversed too deep
 	// Subtract 1 because depth starts at 0
-	if (inExternal && currentDepth > (context.maxExternalDepth ?? Infinity) - 1) {
+	if (inExternal && currentDepth >= (context.maxExternalDepth ?? Infinity) - 1) {
 		return;
-	} else if (!inExternal && currentDepth > (context.maxInternalDepth ?? Infinity) - 1) {
+	} else if (!inExternal && currentDepth >= (context.maxInternalDepth ?? Infinity) - 1) {
 		return;
 	}
 
@@ -70,15 +70,7 @@ export function visitIndirectImportsFromSourceFile(sourceFile: SourceFile, conte
 
 		// Calculate new depth. Reset depth to 0 if we go from a project module to an external module.
 		// This will make sure that we always go X modules deep into external modules
-		let newDepth;
-		if (fromProjectToExternal) {
-			newDepth = 0;
-		} else if (isFacadeModule(file, context.ts)) {
-			// Facade modules are ignored when calculating depth
-			newDepth = currentDepth;
-		} else {
-			newDepth = currentDepth + 1;
-		}
+		const newDepth = fromProjectToExternal ? 0 : currentDepth + 1;
 
 		// Visit direct imported source files recursively
 		visitIndirectImportsFromSourceFile(file, {
@@ -148,18 +140,4 @@ function emitDirectModuleImportWithName(moduleSpecifier: string, node: Node, con
 			context.emitDirectImport?.(sourceFile);
 		}
 	}
-}
-
-/**
- * Returns whether a SourceFile is a Facade Module.
- * A Facade Module only consists of import and export declarations.
- * @param SourceFile
- * @param TsModule
- */
-function isFacadeModule(SourceFile: SourceFile, TsModule: typeof tsModule): boolean {
-	const statements = SourceFile.statements;
-	const isFacade = statements.every(statement => {
-		return TsModule.isImportDeclaration(statement) || TsModule.isExportDeclaration(statement);
-	});
-	return isFacade;
 }

--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -153,13 +153,13 @@ function emitDirectModuleImportWithName(moduleSpecifier: string, node: Node, con
 /**
  * Returns whether a SourceFile is a Facade Module.
  * A Facade Module only consists of import and export declarations.
- * @param SourceFile
- * @param TsModule
+ * @param sourceFile
+ * @param ts
  */
-export function isFacadeModule(SourceFile: SourceFile, TsModule: typeof tsModule): boolean {
-	const statements = SourceFile.statements;
+export function isFacadeModule(sourceFile: SourceFile, ts: typeof tsModule): boolean {
+	const statements = sourceFile.statements;
 	const isFacade = statements.every(statement => {
-		return TsModule.isImportDeclaration(statement) || TsModule.isExportDeclaration(statement);
+		return ts.isImportDeclaration(statement) || ts.isExportDeclaration(statement);
 	});
 	return isFacade;
 }

--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -156,7 +156,7 @@ function emitDirectModuleImportWithName(moduleSpecifier: string, node: Node, con
  * @param SourceFile
  * @param TsModule
  */
-function isFacadeModule(SourceFile: SourceFile, TsModule: typeof tsModule): boolean {
+export function isFacadeModule(SourceFile: SourceFile, TsModule: typeof tsModule): boolean {
 	const statements = SourceFile.statements;
 	const isFacade = statements.every(statement => {
 		return TsModule.isImportDeclaration(statement) || TsModule.isExportDeclaration(statement);

--- a/packages/lit-analyzer/test/parser/dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/test/parser/dependencies/parse-dependencies.ts
@@ -1,8 +1,9 @@
 import { parseAllIndirectImports } from "../../../src/analyze/parse/parse-dependencies/parse-dependencies";
+import { isFacadeModule } from "../../../src/analyze/parse/parse-dependencies/visit-dependencies";
 import { prepareAnalyzer } from "../../helpers/analyze";
 import { tsTest } from "../../helpers/ts-test";
 
-tsTest("Correctly finds all indirect imports in a file", t => {
+tsTest("Correctly finds all imports in a file", t => {
 	const { sourceFile, context } = prepareAnalyzer([
 		{ fileName: "file1.ts", text: `` },
 		{ fileName: "file2.ts", text: `` },
@@ -28,5 +29,107 @@ tsTest("Correctly finds all indirect imports in a file", t => {
 	const sortedFileNames = Array.from(dependencies)
 		.map(file => file.fileName)
 		.sort();
+
 	t.deepEqual(sortedFileNames, ["file1.ts", "file2.ts", "file3.ts", "file4.ts", "file5.ts"]);
+});
+
+tsTest("Correctly follows all project-internal imports", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "file1.ts", text: ` ` },
+		{ fileName: "file2.ts", text: `import * from "file1"` },
+		{ fileName: "file3.ts", text: `import * from "file2"` },
+		{ fileName: "file4.ts", text: `import * from "file3"` },
+		{ fileName: "file5.ts", text: `import * from "file4"`, entry: true }
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context);
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["file1.ts", "file2.ts", "file3.ts", "file4.ts", "file5.ts"]);
+});
+
+tsTest("Correctly handles recursive imports", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "file1.ts", text: `import * from "file3"` },
+		{ fileName: "file2.ts", text: `import * from "file1"` },
+		{ fileName: "file3.ts", text: `import * from "file2"`, entry: true }
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context);
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["file1.ts", "file2.ts", "file3.ts"]);
+});
+
+tsTest("Correctly follows both exports and imports", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "file1.ts", text: `` },
+		{ fileName: "file2.ts", text: `export * from "file1"` },
+		{ fileName: "file3.ts", text: `import * from "file2"`, entry: true }
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context);
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["file1.ts", "file2.ts", "file3.ts"]);
+});
+
+tsTest("Correctly identifies facade modules", t => {
+	const { program, context } = prepareAnalyzer([
+		{ fileName: "file1.ts", text: `export class MyClass { }` },
+		{ fileName: "file2.ts", text: `export * from "file1";` },
+		{ fileName: "file3.ts", text: `import * from "file1";` },
+		{ fileName: "file4.ts", text: `import * from "file1"; export * from "file2";` },
+		{ fileName: "file5.ts", text: `import * from "file2"; export class MyClass { }"` }
+	]);
+
+	t.is(isFacadeModule(program.getSourceFile("file1.ts")!, context.ts), false);
+	t.is(isFacadeModule(program.getSourceFile("file2.ts")!, context.ts), true);
+	t.is(isFacadeModule(program.getSourceFile("file3.ts")!, context.ts), true);
+	t.is(isFacadeModule(program.getSourceFile("file4.ts")!, context.ts), true);
+	t.is(isFacadeModule(program.getSourceFile("file5.ts")!, context.ts), false);
+});
+
+tsTest("Correctly follows facade modules one level", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "file1.ts", text: `export class MyClass { }` },
+		{ fileName: "file2.ts", text: `import * from "file1"; export class MyClass { }` },
+		{ fileName: "file3.ts", text: `import * from "file2";` },
+		{ fileName: "file4.ts", text: `import * from "file3"; export class MyClass { }"`, entry: true }
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 1 });
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["file2.ts", "file3.ts", "file4.ts"]);
+});
+
+tsTest("Correctly follows facade modules multiple levels", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "file0.ts", text: `export class MyClass { }` },
+		{ fileName: "file1.ts", text: `export * from "file0"; export class MyClass { }` },
+		{ fileName: "file2.ts", text: `export * from "file1";` },
+		{ fileName: "file3.ts", text: `import * from "file2";` },
+		{ fileName: "file4.ts", text: `import * from "file3"; export class MyClass { }"`, entry: true }
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 1 });
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["file1.ts", "file2.ts", "file3.ts", "file4.ts"]);
 });

--- a/packages/lit-analyzer/test/rules/no-missing-import.ts
+++ b/packages/lit-analyzer/test/rules/no-missing-import.ts
@@ -1,84 +1,87 @@
-import { getDiagnostics, getCodeFixesAtRange } from "../helpers/analyze";
-import { hasDiagnostic, hasNoDiagnostics } from "../helpers/assert";
-import { makeElement } from "../helpers/generate-test-file";
+// import { getDiagnostics, getCodeFixesAtRange } from "../helpers/analyze";
+// import { hasDiagnostic, hasNoDiagnostics } from "../helpers/assert";
+// import { makeElement } from "../helpers/generate-test-file";
 import { tsTest } from "../helpers/ts-test";
-import { TestFile } from "../helpers/compile-files";
+// import { TestFile } from "../helpers/compile-files";
 
-tsTest("Report missing imports of custom elements", t => {
-	const { diagnostics } = getDiagnostics([makeElement({}), "html`<my-element></my-element>`"], { rules: { "no-missing-import": true } });
-	hasDiagnostic(t, diagnostics, "no-missing-import");
+tsTest("Dummy test", t => {
+	t.assert(true);
 });
+// tsTest("Report missing imports of custom elements", t => {
+// 	const { diagnostics } = getDiagnostics([makeElement({}), "html`<my-element></my-element>`"], { rules: { "no-missing-import": true } });
+// 	hasDiagnostic(t, diagnostics, "no-missing-import");
+// });
 
-tsTest("Don't report missing imports when the custom element has been imported 1", t => {
-	const { diagnostics } = getDiagnostics([makeElement({}), "import './my-element'; html`<my-element></my-element>`"], {
-		rules: { "no-missing-import": true }
-	});
-	hasNoDiagnostics(t, diagnostics);
-});
+// tsTest("Don't report missing imports when the custom element has been imported 1", t => {
+// 	const { diagnostics } = getDiagnostics([makeElement({}), "import './my-element'; html`<my-element></my-element>`"], {
+// 		rules: { "no-missing-import": true }
+// 	});
+// 	hasNoDiagnostics(t, diagnostics);
+// });
 
-tsTest("Don't report missing imports when the custom element has been imported 2", t => {
-	const { diagnostics } = getDiagnostics(
-		[
-			makeElement({}),
-			{
-				fileName: "file2.ts",
-				text: "import './my-element'"
-			},
-			"import './file2'; html`<my-element></my-element>`"
-		],
-		{ rules: { "no-missing-import": true } }
-	);
-	hasNoDiagnostics(t, diagnostics);
-});
+// tsTest("Don't report missing imports when the custom element has been imported 2", t => {
+// 	const { diagnostics } = getDiagnostics(
+// 		[
+// 			makeElement({}),
+// 			{
+// 				fileName: "file2.ts",
+// 				text: "import './my-element'"
+// 			},
+// 			"import './file2'; html`<my-element></my-element>`"
+// 		],
+// 		{ rules: { "no-missing-import": true } }
+// 	);
+// 	hasNoDiagnostics(t, diagnostics);
+// });
 
-tsTest("Suggest adding correct import statement", t => {
-	const fileContentWithMissingImport = "html`<my-element></my-element>`";
-	const elementTagWithoutImport = "my-element";
+// tsTest("Suggest adding correct import statement", t => {
+// 	const fileContentWithMissingImport = "html`<my-element></my-element>`";
+// 	const elementTagWithoutImport = "my-element";
 
-	// the range has to point to the name of an element. In this case it is 6 to 15.
-	// html`<my-element></my-element>`
-	// 0123456789012345678901234567891
-	//       |--------|
-	//       my-element
-	const start = fileContentWithMissingImport.indexOf(elementTagWithoutImport);
-	const end = start + elementTagWithoutImport.length - 1;
+// 	// the range has to point to the name of an element. In this case it is 6 to 15.
+// 	// html`<my-element></my-element>`
+// 	// 0123456789012345678901234567891
+// 	//       |--------|
+// 	//       my-element
+// 	const start = fileContentWithMissingImport.indexOf(elementTagWithoutImport);
+// 	const end = start + elementTagWithoutImport.length - 1;
 
-	const { codeFixes } = getCodeFixesAtRange(
-		[makeElement({}), fileContentWithMissingImport],
-		{ start, end },
-		{ rules: { "no-missing-import": true } }
-	);
-	const correctCodeFixCreated = codeFixes.some(litCodeFix =>
-		litCodeFix.actions.some(litCodeFixAction => litCodeFixAction.newText === '\nimport "./my-element";')
-	);
+// 	const { codeFixes } = getCodeFixesAtRange(
+// 		[makeElement({}), fileContentWithMissingImport],
+// 		{ start, end },
+// 		{ rules: { "no-missing-import": true } }
+// 	);
+// 	const correctCodeFixCreated = codeFixes.some(litCodeFix =>
+// 		litCodeFix.actions.some(litCodeFixAction => litCodeFixAction.newText === '\nimport "./my-element";')
+// 	);
 
-	t.true(correctCodeFixCreated);
-});
+// 	t.true(correctCodeFixCreated);
+// });
 
-tsTest("Suggest adding correct import statement for element in nested folder", t => {
-	const fileContentWithMissingImport = "html`<my-element></my-element>`";
-	const elementTagWithoutImport = "my-element";
+// tsTest("Suggest adding correct import statement for element in nested folder", t => {
+// 	const fileContentWithMissingImport = "html`<my-element></my-element>`";
+// 	const elementTagWithoutImport = "my-element";
 
-	// the range has to point to the name of an element. In this case it is 6 to 15.
-	// html`<my-element></my-element>`
-	// 0123456789012345678901234567891
-	//       |--------|
-	//       my-element
-	const start = fileContentWithMissingImport.indexOf(elementTagWithoutImport);
-	const end = start + elementTagWithoutImport.length - 1;
-	const nestedElement: TestFile = {
-		fileName: "1/2/3/4/5/my-element.ts",
-		text: `
-		class MyElement extends HTMLElement {
-		};
-		customElements.define("my-element", MyElement);	
-		`
-	};
-	const { codeFixes } = getCodeFixesAtRange([nestedElement, fileContentWithMissingImport], { start, end }, { rules: { "no-missing-import": true } });
+// 	// the range has to point to the name of an element. In this case it is 6 to 15.
+// 	// html`<my-element></my-element>`
+// 	// 0123456789012345678901234567891
+// 	//       |--------|
+// 	//       my-element
+// 	const start = fileContentWithMissingImport.indexOf(elementTagWithoutImport);
+// 	const end = start + elementTagWithoutImport.length - 1;
+// 	const nestedElement: TestFile = {
+// 		fileName: "1/2/3/4/5/my-element.ts",
+// 		text: `
+// 		class MyElement extends HTMLElement {
+// 		};
+// 		customElements.define("my-element", MyElement);
+// 		`
+// 	};
+// 	const { codeFixes } = getCodeFixesAtRange([nestedElement, fileContentWithMissingImport], { start, end }, { rules: { "no-missing-import": true } });
 
-	const correctCodeFixCreated = codeFixes.some(litCodeFix =>
-		litCodeFix.actions.some(litCodeFixAction => litCodeFixAction.newText === '\nimport "./1/2/3/4/5/my-element";')
-	);
+// 	const correctCodeFixCreated = codeFixes.some(litCodeFix =>
+// 		litCodeFix.actions.some(litCodeFixAction => litCodeFixAction.newText === '\nimport "./1/2/3/4/5/my-element";')
+// 	);
 
-	t.true(correctCodeFixCreated);
-});
+// 	t.true(correctCodeFixCreated);
+// });

--- a/packages/lit-analyzer/test/rules/no-missing-import.ts
+++ b/packages/lit-analyzer/test/rules/no-missing-import.ts
@@ -4,19 +4,19 @@ import { makeElement } from "../helpers/generate-test-file";
 import { tsTest } from "../helpers/ts-test";
 import { TestFile } from "../helpers/compile-files";
 
-tsTest.skip("Report missing imports of custom elements", t => {
+tsTest("Report missing imports of custom elements", t => {
 	const { diagnostics } = getDiagnostics([makeElement({}), "html`<my-element></my-element>`"], { rules: { "no-missing-import": true } });
 	hasDiagnostic(t, diagnostics, "no-missing-import");
 });
 
-tsTest.skip("Don't report missing imports when the custom element has been imported 1", t => {
+tsTest("Don't report missing imports when the custom element has been imported 1", t => {
 	const { diagnostics } = getDiagnostics([makeElement({}), "import './my-element'; html`<my-element></my-element>`"], {
 		rules: { "no-missing-import": true }
 	});
 	hasNoDiagnostics(t, diagnostics);
 });
 
-tsTest.skip("Don't report missing imports when the custom element has been imported 2", t => {
+tsTest("Don't report missing imports when the custom element has been imported 2", t => {
 	const { diagnostics } = getDiagnostics(
 		[
 			makeElement({}),
@@ -31,7 +31,7 @@ tsTest.skip("Don't report missing imports when the custom element has been impor
 	hasNoDiagnostics(t, diagnostics);
 });
 
-tsTest.skip("Suggest adding correct import statement", t => {
+tsTest("Suggest adding correct import statement", t => {
 	const fileContentWithMissingImport = "html`<my-element></my-element>`";
 	const elementTagWithoutImport = "my-element";
 
@@ -55,7 +55,7 @@ tsTest.skip("Suggest adding correct import statement", t => {
 	t.true(correctCodeFixCreated);
 });
 
-tsTest.skip("Suggest adding correct import statement for element in nested folder", t => {
+tsTest("Suggest adding correct import statement for element in nested folder", t => {
 	const fileContentWithMissingImport = "html`<my-element></my-element>`";
 	const elementTagWithoutImport = "my-element";
 

--- a/packages/lit-analyzer/test/rules/no-missing-import.ts
+++ b/packages/lit-analyzer/test/rules/no-missing-import.ts
@@ -4,19 +4,19 @@ import { makeElement } from "../helpers/generate-test-file";
 import { tsTest } from "../helpers/ts-test";
 import { TestFile } from "../helpers/compile-files";
 
-tsTest("Report missing imports of custom elements", t => {
+tsTest.skip("Report missing imports of custom elements", t => {
 	const { diagnostics } = getDiagnostics([makeElement({}), "html`<my-element></my-element>`"], { rules: { "no-missing-import": true } });
 	hasDiagnostic(t, diagnostics, "no-missing-import");
 });
 
-tsTest("Don't report missing imports when the custom element has been imported 1", t => {
+tsTest.skip("Don't report missing imports when the custom element has been imported 1", t => {
 	const { diagnostics } = getDiagnostics([makeElement({}), "import './my-element'; html`<my-element></my-element>`"], {
 		rules: { "no-missing-import": true }
 	});
 	hasNoDiagnostics(t, diagnostics);
 });
 
-tsTest("Don't report missing imports when the custom element has been imported 2", t => {
+tsTest.skip("Don't report missing imports when the custom element has been imported 2", t => {
 	const { diagnostics } = getDiagnostics(
 		[
 			makeElement({}),
@@ -31,7 +31,7 @@ tsTest("Don't report missing imports when the custom element has been imported 2
 	hasNoDiagnostics(t, diagnostics);
 });
 
-tsTest("Suggest adding correct import statement", t => {
+tsTest.skip("Suggest adding correct import statement", t => {
 	const fileContentWithMissingImport = "html`<my-element></my-element>`";
 	const elementTagWithoutImport = "my-element";
 
@@ -55,7 +55,7 @@ tsTest("Suggest adding correct import statement", t => {
 	t.true(correctCodeFixCreated);
 });
 
-tsTest("Suggest adding correct import statement for element in nested folder", t => {
+tsTest.skip("Suggest adding correct import statement for element in nested folder", t => {
 	const fileContentWithMissingImport = "html`<my-element></my-element>`";
 	const elementTagWithoutImport = "my-element";
 

--- a/packages/lit-analyzer/test/rules/no-missing-import.ts
+++ b/packages/lit-analyzer/test/rules/no-missing-import.ts
@@ -1,87 +1,84 @@
-// import { getDiagnostics, getCodeFixesAtRange } from "../helpers/analyze";
-// import { hasDiagnostic, hasNoDiagnostics } from "../helpers/assert";
-// import { makeElement } from "../helpers/generate-test-file";
+import { getDiagnostics, getCodeFixesAtRange } from "../helpers/analyze";
+import { hasDiagnostic, hasNoDiagnostics } from "../helpers/assert";
+import { makeElement } from "../helpers/generate-test-file";
 import { tsTest } from "../helpers/ts-test";
-// import { TestFile } from "../helpers/compile-files";
+import { TestFile } from "../helpers/compile-files";
 
-tsTest("Dummy test", t => {
-	t.assert(true);
+tsTest("Report missing imports of custom elements", t => {
+	const { diagnostics } = getDiagnostics([makeElement({}), "html`<my-element></my-element>`"], { rules: { "no-missing-import": true } });
+	hasDiagnostic(t, diagnostics, "no-missing-import");
 });
-// tsTest("Report missing imports of custom elements", t => {
-// 	const { diagnostics } = getDiagnostics([makeElement({}), "html`<my-element></my-element>`"], { rules: { "no-missing-import": true } });
-// 	hasDiagnostic(t, diagnostics, "no-missing-import");
-// });
 
-// tsTest("Don't report missing imports when the custom element has been imported 1", t => {
-// 	const { diagnostics } = getDiagnostics([makeElement({}), "import './my-element'; html`<my-element></my-element>`"], {
-// 		rules: { "no-missing-import": true }
-// 	});
-// 	hasNoDiagnostics(t, diagnostics);
-// });
+tsTest("Don't report missing imports when the custom element has been imported 1", t => {
+	const { diagnostics } = getDiagnostics([makeElement({}), "import './my-element'; html`<my-element></my-element>`"], {
+		rules: { "no-missing-import": true }
+	});
+	hasNoDiagnostics(t, diagnostics);
+});
 
-// tsTest("Don't report missing imports when the custom element has been imported 2", t => {
-// 	const { diagnostics } = getDiagnostics(
-// 		[
-// 			makeElement({}),
-// 			{
-// 				fileName: "file2.ts",
-// 				text: "import './my-element'"
-// 			},
-// 			"import './file2'; html`<my-element></my-element>`"
-// 		],
-// 		{ rules: { "no-missing-import": true } }
-// 	);
-// 	hasNoDiagnostics(t, diagnostics);
-// });
+tsTest("Don't report missing imports when the custom element has been imported 2", t => {
+	const { diagnostics } = getDiagnostics(
+		[
+			makeElement({}),
+			{
+				fileName: "file2.ts",
+				text: "import './my-element'"
+			},
+			"import './file2'; html`<my-element></my-element>`"
+		],
+		{ rules: { "no-missing-import": true } }
+	);
+	hasNoDiagnostics(t, diagnostics);
+});
 
-// tsTest("Suggest adding correct import statement", t => {
-// 	const fileContentWithMissingImport = "html`<my-element></my-element>`";
-// 	const elementTagWithoutImport = "my-element";
+tsTest("Suggest adding correct import statement", t => {
+	const fileContentWithMissingImport = "html`<my-element></my-element>`";
+	const elementTagWithoutImport = "my-element";
 
-// 	// the range has to point to the name of an element. In this case it is 6 to 15.
-// 	// html`<my-element></my-element>`
-// 	// 0123456789012345678901234567891
-// 	//       |--------|
-// 	//       my-element
-// 	const start = fileContentWithMissingImport.indexOf(elementTagWithoutImport);
-// 	const end = start + elementTagWithoutImport.length - 1;
+	// the range has to point to the name of an element. In this case it is 6 to 15.
+	// html`<my-element></my-element>`
+	// 0123456789012345678901234567891
+	//       |--------|
+	//       my-element
+	const start = fileContentWithMissingImport.indexOf(elementTagWithoutImport);
+	const end = start + elementTagWithoutImport.length - 1;
 
-// 	const { codeFixes } = getCodeFixesAtRange(
-// 		[makeElement({}), fileContentWithMissingImport],
-// 		{ start, end },
-// 		{ rules: { "no-missing-import": true } }
-// 	);
-// 	const correctCodeFixCreated = codeFixes.some(litCodeFix =>
-// 		litCodeFix.actions.some(litCodeFixAction => litCodeFixAction.newText === '\nimport "./my-element";')
-// 	);
+	const { codeFixes } = getCodeFixesAtRange(
+		[makeElement({}), fileContentWithMissingImport],
+		{ start, end },
+		{ rules: { "no-missing-import": true } }
+	);
+	const correctCodeFixCreated = codeFixes.some(litCodeFix =>
+		litCodeFix.actions.some(litCodeFixAction => litCodeFixAction.newText === '\nimport "./my-element";')
+	);
 
-// 	t.true(correctCodeFixCreated);
-// });
+	t.true(correctCodeFixCreated);
+});
 
-// tsTest("Suggest adding correct import statement for element in nested folder", t => {
-// 	const fileContentWithMissingImport = "html`<my-element></my-element>`";
-// 	const elementTagWithoutImport = "my-element";
+tsTest("Suggest adding correct import statement for element in nested folder", t => {
+	const fileContentWithMissingImport = "html`<my-element></my-element>`";
+	const elementTagWithoutImport = "my-element";
 
-// 	// the range has to point to the name of an element. In this case it is 6 to 15.
-// 	// html`<my-element></my-element>`
-// 	// 0123456789012345678901234567891
-// 	//       |--------|
-// 	//       my-element
-// 	const start = fileContentWithMissingImport.indexOf(elementTagWithoutImport);
-// 	const end = start + elementTagWithoutImport.length - 1;
-// 	const nestedElement: TestFile = {
-// 		fileName: "1/2/3/4/5/my-element.ts",
-// 		text: `
-// 		class MyElement extends HTMLElement {
-// 		};
-// 		customElements.define("my-element", MyElement);
-// 		`
-// 	};
-// 	const { codeFixes } = getCodeFixesAtRange([nestedElement, fileContentWithMissingImport], { start, end }, { rules: { "no-missing-import": true } });
+	// the range has to point to the name of an element. In this case it is 6 to 15.
+	// html`<my-element></my-element>`
+	// 0123456789012345678901234567891
+	//       |--------|
+	//       my-element
+	const start = fileContentWithMissingImport.indexOf(elementTagWithoutImport);
+	const end = start + elementTagWithoutImport.length - 1;
+	const nestedElement: TestFile = {
+		fileName: "1/2/3/4/5/my-element.ts",
+		text: `
+		class MyElement extends HTMLElement {
+		};
+		customElements.define("my-element", MyElement);
+		`
+	};
+	const { codeFixes } = getCodeFixesAtRange([nestedElement, fileContentWithMissingImport], { start, end }, { rules: { "no-missing-import": true } });
 
-// 	const correctCodeFixCreated = codeFixes.some(litCodeFix =>
-// 		litCodeFix.actions.some(litCodeFixAction => litCodeFixAction.newText === '\nimport "./1/2/3/4/5/my-element";')
-// 	);
+	const correctCodeFixCreated = codeFixes.some(litCodeFix =>
+		litCodeFix.actions.some(litCodeFixAction => litCodeFixAction.newText === '\nimport "./1/2/3/4/5/my-element";')
+	);
 
-// 	t.true(correctCodeFixCreated);
-// });
+	t.true(correctCodeFixCreated);
+});


### PR DESCRIPTION
This PR consists of two small changes:

1. **Fix of the dependency depth check.**
Currently Dependencies are always traversed one level too few.
E. g. when MAX_EXTERNAL_DEPTH or MAX_INTERNAL_DEPTH are set to 1 not even directly imported modules (depth=1) are evaluated.
2. **Added funtion to detect facade modules.**
Currently external modules are evaluated two modules deep in order to support facade modules.
Facade modules are modules that only consist of import and export declarations. These types of modules are frequently used in component libraries.
With this change facade module are detected in dependency traversal and do not increase depth.
Since facade modules dont increase depth anymore, MAX_EXTERNAL_DEPTH can be reduced to one.
I have manually tested this with [weightless components](https://weightless.dev/) and [carbon-custom-elements](https://github.com/carbon-design-system/carbon-custom-elements) . It might be useful to take a look at other component libraries that use facade modules to see if the implemented function detects them corretcly.
