### PR TITLE
Add tests for external modules

### DIFF
--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -138,14 +138,12 @@ function emitDirectModuleImportWithName(moduleSpecifier: string, node: Node, con
 		? context.project.getResolvedModuleWithFailedLookupLocationsFromCache(moduleSpecifier, fromSourceFile.fileName)
 		: "getResolvedModuleWithFailedLookupLocationsFromCache" in context.program
 		? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-		  (context.program as any)["getResolvedModuleWithFailedLookupLocationsFromCache"](moduleSpecifier, node.getSourceFile().fileName)
+		  (context.program as any)["getResolvedModuleWithFailedLookupLocationsFromCache"](moduleSpecifier, fromSourceFile.fileName)
 		: undefined;
 
-	const mod = result != null ? result.resolvedModule : undefined;
-
-	if (mod != null) {
-		const sourceFile = context.program.getSourceFile(mod.resolvedFileName);
-
+	if (result?.resolvedModule?.resolvedFileName != null) {
+		const resolvedModule = result.resolvedModule;
+		const sourceFile = context.program.getSourceFile(resolvedModule.resolvedFileName);
 		if (sourceFile != null) {
 			context.emitDirectImport?.(sourceFile);
 		}

--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -68,16 +68,18 @@ export function visitIndirectImportsFromSourceFile(sourceFile: SourceFile, conte
 		 continue;
 		 }*/
 
-		// Calculate new depth. Reset depth to 0 if we go from a project module to an external module.
+		// Calculate new depth. Reset depth to 1 if we go from a project module to an external module.
 		// This will make sure that we always go X modules deep into external modules
 		let newDepth;
 		if (fromProjectToExternal) {
-			newDepth = 0;
-		} else if (isFacadeModule(file, context.ts)) {
-			// Facade modules are ignored when calculating depth
-			newDepth = currentDepth;
+			newDepth = 1;
 		} else {
 			newDepth = currentDepth + 1;
+		}
+
+		if (isFacadeModule(file, context.ts)) {
+			// Facade modules are ignored when calculating depth
+			newDepth--;
 		}
 
 		// Visit direct imported source files recursively

--- a/packages/lit-analyzer/test/helpers/compile-files.ts
+++ b/packages/lit-analyzer/test/helpers/compile-files.ts
@@ -114,7 +114,7 @@ export function compileFiles(inputFiles: TestFile[] | TestFile = []): { program:
 	// We need to overwrite this so the traversal of external modules can be tested.
 	program.isSourceFileFromExternalLibrary = (sourceFile: SourceFile): boolean => {
 		const filename = sourceFile.fileName;
-		return filename.includes("node_modules") ? true : false;
+		return filename.includes("node_modules");
 	};
 
 	const entrySourceFile = entryFile.fileName != null ? program.getSourceFile(entryFile.fileName)! : program.getSourceFiles()[0];

--- a/packages/lit-analyzer/test/helpers/compile-files.ts
+++ b/packages/lit-analyzer/test/helpers/compile-files.ts
@@ -111,6 +111,12 @@ export function compileFiles(inputFiles: TestFile[] | TestFile = []): { program:
 		host: compilerHost
 	});
 
+	// We need to overwrite this so the traversal of external modules can be tested.
+	program.isSourceFileFromExternalLibrary = (sourceFile: SourceFile): boolean => {
+		const filename = sourceFile.fileName;
+		return filename.includes("node_modules") ? true : false;
+	};
+
 	const entrySourceFile = entryFile.fileName != null ? program.getSourceFile(entryFile.fileName)! : program.getSourceFiles()[0];
 
 	return {

--- a/packages/lit-analyzer/test/parser/dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/test/parser/dependencies/parse-dependencies.ts
@@ -15,7 +15,7 @@ tsTest("Correctly finds all imports in a file", t => {
 				import "file1";
 				import * as f2 from "file2";
 				import { } from "file3";
-				
+
 				(async () => {
 					await import("file4");
 				})();
@@ -33,7 +33,7 @@ tsTest("Correctly finds all imports in a file", t => {
 	t.deepEqual(sortedFileNames, ["file1.ts", "file2.ts", "file3.ts", "file4.ts", "file5.ts"]);
 });
 
-tsTest("Correctly follows all project-internal imports", t => {
+tsTest("Correctly follows all project-internal imports with (default) maxInternalDepth=Infinity", t => {
 	const { sourceFile, context } = prepareAnalyzer([
 		{ fileName: "file1.ts", text: ` ` },
 		{ fileName: "file2.ts", text: `import * from "file1"` },
@@ -49,6 +49,152 @@ tsTest("Correctly follows all project-internal imports", t => {
 		.sort();
 
 	t.deepEqual(sortedFileNames, ["file1.ts", "file2.ts", "file3.ts", "file4.ts", "file5.ts"]);
+});
+
+tsTest("Correctly follows project-internal imports with maxInternalDepth=1", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "file1.ts", text: `export class MyClass { }` },
+		{ fileName: "file2.ts", text: `import * from "file1";export class MyClass { }` },
+		{ fileName: "file3.ts", text: `import * from "file2";export class MyClass { }`, entry: true }
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 1 });
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["file2.ts", "file3.ts"]);
+});
+
+tsTest("Correctly follows project-internal imports with maxInternalDepth=5", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "file1.ts", text: `export class MyClass { }` },
+		{ fileName: "file2.ts", text: `import * from "file1";export class MyClass { }` },
+		{ fileName: "file3.ts", text: `import * from "file2";export class MyClass { }` },
+		{ fileName: "file4.ts", text: `import * from "file3";export class MyClass { }` },
+		{ fileName: "file5.ts", text: `import * from "file4";export class MyClass { }` },
+		{ fileName: "file6.ts", text: `import * from "file5";export class MyClass { }` },
+		{ fileName: "file7.ts", text: `import * from "file6";export class MyClass { }`, entry: true }
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 5 });
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["file2.ts", "file3.ts", "file4.ts", "file5.ts", "file6.ts", "file7.ts"]);
+});
+
+tsTest("Correctly follows project-external imports with maxExternalDepth=1", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
+		{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
+		{ fileName: "node_modules/file3.ts", text: `import * from "./file2";export class MyClass { }`, entry: true }
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context, { maxExternalDepth: 1 });
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["node_modules/file2.ts", "node_modules/file3.ts"]);
+});
+
+tsTest("Correctly follows project-external imports with maxExternalDepth=5", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
+		{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
+		{ fileName: "node_modules/file3.ts", text: `import * from "./file2";export class MyClass { }` },
+		{ fileName: "node_modules/file4.ts", text: `import * from "./file3";export class MyClass { }` },
+		{ fileName: "node_modules/file5.ts", text: `import * from "./file4";export class MyClass { }` },
+		{ fileName: "node_modules/file6.ts", text: `import * from "./file5";export class MyClass { }` },
+		{ fileName: "node_modules/file7.ts", text: `import * from "./file6";export class MyClass { }`, entry: true }
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context, { maxExternalDepth: 5 });
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, [
+		"node_modules/file2.ts",
+		"node_modules/file3.ts",
+		"node_modules/file4.ts",
+		"node_modules/file5.ts",
+		"node_modules/file6.ts",
+		"node_modules/file7.ts"
+	]);
+});
+
+tsTest("Correctly resets depth when going from internal to external module with maxInternalDepth=1", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
+		{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
+		{ fileName: "file3.ts", text: `import * from "./node_modules/file2";export class MyClass { }`, entry: true }
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 1 });
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+	t.deepEqual(sortedFileNames, ["file3.ts", "node_modules/file2.ts"]);
+});
+
+tsTest("Correctly resets depth when going from internal to external module with maxInternalDepth=2", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
+		{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
+		{ fileName: "file3.ts", text: `import * from "./node_modules/file2";export class MyClass { }` },
+		{ fileName: "file4.ts", text: `import * from "./file3";export class MyClass { }`, entry: true }
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 2 });
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["file3.ts", "file4.ts", "node_modules/file2.ts"]);
+});
+
+tsTest("Correctly resets depth when going from internal to external module when first external module is a facade module", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
+		{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
+		{ fileName: "node_modules/file3.ts", text: `import * from "./file2"` },
+		{ fileName: "file4.ts", text: `import * from "./node_modules/file3";export class MyClass { }`, entry: true }
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 1 });
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["file4.ts", "node_modules/file2.ts", "node_modules/file3.ts"]);
+});
+
+tsTest("Correctly follows modules when going from internal to external module when second external module is a facade module", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
+		{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
+		{ fileName: "node_modules/file3.ts", text: `import * from "./file2"` },
+		{ fileName: "node_modules/file4.ts", text: `import * from "./file3";export class MyClass { }` },
+		{ fileName: "file5.ts", text: `import * from "./node_modules/file4";export class MyClass { }`, entry: true }
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 1, maxExternalDepth: 2 });
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["file5.ts", "node_modules/file2.ts", "node_modules/file3.ts", "node_modules/file4.ts"]);
 });
 
 tsTest("Correctly handles recursive imports", t => {


### PR DESCRIPTION
Tests for the traversal of external modules were added.
In order to be able to detect external modules, the ["isSourceFileFromExternalLibrary" function](https://github.com/FelixSchuSi/lit-analyzer/blob/5093aafbc0076b9d282613e4ef8c31eaacab4387/packages/lit-analyzer/test/helpers/compile-files.ts#L115-L118) now 
 gets overwritten when testing.

I also changed the way the newDepth is determined in module traversal since it didnt work as expected when going from an interal to an external module when the first external module was not a facade module.

