### PR TITLE
Make maxInternalDepth and maxExternalDepth configurable.

### DIFF
--- a/docs/readme/config-table.md
+++ b/docs/readme/config-table.md
@@ -11,3 +11,5 @@
 | `globalAttributes` | List of html attributes names that you expect to be present at all times. | `string[]` | |
 | `globalEvents` | List of event names that you expect to be present at all times | `string[]` | |
 | `customHtmlData` | This plugin supports the [custom vscode html data format](https://code.visualstudio.com/updates/v1_31#_html-and-css-custom-data-support) through this setting. | [Vscode Custom HTML Data Format](https://github.com/Microsoft/vscode-html-languageservice/blob/master/docs/customData.md). Supports arrays, objects and relative file paths | |
+| `maxProjectImportDepth` | Determines how many modules deep dependencies are followed to determine whether a custom element is available in the current file. When `-1` is used, dependencies will be followed infinitely deep. | `number` | `-1` |
+| `maxNodeModuleImportDepth` | Determines how many modules deep dependencies in __npm packages__ are followed to determine whether a custom element is available in the current file. When `-1` is used, dependencies in __npm packages__ will be followed infinitely deep.| `number` | `1` |

--- a/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
+++ b/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
@@ -127,8 +127,8 @@ export interface LitAnalyzerConfig {
 	format: { disable: boolean };
 	dontShowSuggestions: boolean;
 	dontSuggestConfigChanges: boolean;
-	moduleTraversalDepthInternal: number;
-	moduleTraversalDepthExternal: number;
+	maxNodeModuleImportDepth: number;
+	maxProjectImportDepth: number;
 
 	htmlTemplateTags: string[];
 	cssTemplateTags: string[];
@@ -173,8 +173,8 @@ export function makeConfig(userOptions: Partial<LitAnalyzerConfig> = {}): LitAna
 		},
 		dontSuggestConfigChanges: userOptions.dontSuggestConfigChanges || false,
 		dontShowSuggestions: userOptions.dontShowSuggestions || getDeprecatedOption(userOptions, "skipSuggestions") || false,
-		moduleTraversalDepthInternal: parseModuleTraversalDepth(userOptions.moduleTraversalDepthInternal, Infinity),
-		moduleTraversalDepthExternal: parseModuleTraversalDepth(userOptions.moduleTraversalDepthExternal, 1),
+		maxProjectImportDepth: parseModuleTraversalDepth(userOptions.maxProjectImportDepth, Infinity),
+		maxNodeModuleImportDepth: parseModuleTraversalDepth(userOptions.maxNodeModuleImportDepth, 1),
 
 		// Template tags
 		htmlTemplateTags: userOptions.htmlTemplateTags || ["html", "raw"],

--- a/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
+++ b/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
@@ -173,8 +173,8 @@ export function makeConfig(userOptions: Partial<LitAnalyzerConfig> = {}): LitAna
 		},
 		dontSuggestConfigChanges: userOptions.dontSuggestConfigChanges || false,
 		dontShowSuggestions: userOptions.dontShowSuggestions || getDeprecatedOption(userOptions, "skipSuggestions") || false,
-		moduleTraversalDepthInternal: userOptions.moduleTraversalDepthInternal || Infinity,
-		moduleTraversalDepthExternal: userOptions.moduleTraversalDepthExternal || 1,
+		moduleTraversalDepthInternal: parseModuleTraversalDepth(userOptions.moduleTraversalDepthInternal, Infinity),
+		moduleTraversalDepthExternal: parseModuleTraversalDepth(userOptions.moduleTraversalDepthExternal, 1),
 
 		// Template tags
 		htmlTemplateTags: userOptions.htmlTemplateTags || ["html", "raw"],
@@ -258,4 +258,19 @@ function getDeprecatedMappedRules(userOptions: Partial<LitAnalyzerConfig>): LitA
 	}
 
 	return mappedDeprecatedRules;
+}
+
+/**
+ * Parses dependency traversal depth from configuration.
+ * The string "Infinity" gets parsed to the number Infinity.
+ * @param value
+ * @param defaultValue
+ */
+function parseModuleTraversalDepth(value: string | number | undefined, defaultValue: number): number {
+	const castedValue = Number(value);
+	if (!(isNaN(castedValue) || castedValue <= 0)) {
+		// cast successful.
+		return castedValue;
+	}
+	return defaultValue;
 }

--- a/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
+++ b/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
@@ -173,8 +173,8 @@ export function makeConfig(userOptions: Partial<LitAnalyzerConfig> = {}): LitAna
 		},
 		dontSuggestConfigChanges: userOptions.dontSuggestConfigChanges || false,
 		dontShowSuggestions: userOptions.dontShowSuggestions || getDeprecatedOption(userOptions, "skipSuggestions") || false,
-		maxProjectImportDepth: parseModuleTraversalDepth(userOptions.maxProjectImportDepth, Infinity),
-		maxNodeModuleImportDepth: parseModuleTraversalDepth(userOptions.maxNodeModuleImportDepth, 1),
+		maxProjectImportDepth: parseImportDepth(userOptions.maxProjectImportDepth, Infinity),
+		maxNodeModuleImportDepth: parseImportDepth(userOptions.maxNodeModuleImportDepth, 1),
 
 		// Template tags
 		htmlTemplateTags: userOptions.htmlTemplateTags || ["html", "raw"],
@@ -262,15 +262,14 @@ function getDeprecatedMappedRules(userOptions: Partial<LitAnalyzerConfig>): LitA
 
 /**
  * Parses dependency traversal depth from configuration.
- * The string "Infinity" gets parsed to the number Infinity.
+ * The number -1 (as well as any other negative number) gets parsed into the number Infinity.
  * @param value
  * @param defaultValue
  */
-function parseModuleTraversalDepth(value: string | number | undefined, defaultValue: number): number {
-	const castedValue = Number(value);
-	if (!(isNaN(castedValue) || castedValue <= 0)) {
-		// cast successful.
-		return castedValue;
+function parseImportDepth(value: number | undefined, defaultValue: number): number {
+	if (value != null) {
+		return value < 0 ? Infinity : value;
+	} else {
+		return defaultValue;
 	}
-	return defaultValue;
 }

--- a/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
+++ b/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
@@ -125,12 +125,13 @@ export interface LitAnalyzerConfig {
 	logging: LitAnalyzerLogging;
 	cwd: string;
 	format: { disable: boolean };
+	dontShowSuggestions: boolean;
+	dontSuggestConfigChanges: boolean;
+	moduleTraversalDepthInternal: number;
+	moduleTraversalDepthExternal: number;
 
 	htmlTemplateTags: string[];
 	cssTemplateTags: string[];
-
-	dontShowSuggestions: boolean;
-	dontSuggestConfigChanges: boolean;
 
 	globalTags: string[];
 	globalAttributes: string[];
@@ -172,6 +173,8 @@ export function makeConfig(userOptions: Partial<LitAnalyzerConfig> = {}): LitAna
 		},
 		dontSuggestConfigChanges: userOptions.dontSuggestConfigChanges || false,
 		dontShowSuggestions: userOptions.dontShowSuggestions || getDeprecatedOption(userOptions, "skipSuggestions") || false,
+		moduleTraversalDepthInternal: userOptions.moduleTraversalDepthInternal || Infinity,
+		moduleTraversalDepthExternal: userOptions.moduleTraversalDepthExternal || 1,
 
 		// Template tags
 		htmlTemplateTags: userOptions.htmlTemplateTags || ["html", "raw"],

--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
@@ -3,11 +3,6 @@ import { ComponentDefinition } from "web-component-analyzer";
 import { LitAnalyzerContext } from "../../lit-analyzer-context";
 import { visitIndirectImportsFromSourceFile } from "./visit-dependencies";
 
-// Depth constants
-const MAX_EXTERNAL_DEPTH = 1;
-
-const MAX_INTERNAL_DEPTH = Infinity;
-
 // A cache used to prevent traversing through entire source files multiple times to find direct imports
 const DIRECT_IMPORT_CACHE = new WeakMap<SourceFile, Set<SourceFile>>();
 
@@ -79,8 +74,8 @@ export function parseAllIndirectImports(
 		program: context.program,
 		ts: context.ts,
 		directImportCache: DIRECT_IMPORT_CACHE,
-		maxExternalDepth: maxExternalDepth ?? MAX_EXTERNAL_DEPTH,
-		maxInternalDepth: maxInternalDepth ?? MAX_INTERNAL_DEPTH,
+		maxExternalDepth: maxExternalDepth ?? context.config.moduleTraversalDepthExternal,
+		maxInternalDepth: maxInternalDepth ?? context.config.moduleTraversalDepthInternal,
 		emitIndirectImport(file: SourceFile): boolean {
 			if (importedSourceFiles.has(file)) {
 				return false;

--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
@@ -74,8 +74,8 @@ export function parseAllIndirectImports(
 		program: context.program,
 		ts: context.ts,
 		directImportCache: DIRECT_IMPORT_CACHE,
-		maxExternalDepth: maxExternalDepth ?? context.config.moduleTraversalDepthExternal,
-		maxInternalDepth: maxInternalDepth ?? context.config.moduleTraversalDepthInternal,
+		maxExternalDepth: maxExternalDepth ?? context.config.maxNodeModuleImportDepth,
+		maxInternalDepth: maxInternalDepth ?? context.config.maxProjectImportDepth,
 		emitIndirectImport(file: SourceFile): boolean {
 			if (importedSourceFiles.has(file)) {
 				return false;

--- a/packages/lit-analyzer/src/cli/analyze-command.ts
+++ b/packages/lit-analyzer/src/cli/analyze-command.ts
@@ -193,14 +193,14 @@ function readLitAnalyzerConfigFromCliConfig(cliConfig: LitAnalyzerCliConfig): Pa
 		config.logging = cliConfig.debug ? "verbose" : "off";
 	}
 
-	// Assign "moduleTraversalDepthInternal" setting from the CLI command (which overwrites tsconfig rules)
-	if (cliConfig.moduleTraversalDepthInternal != null) {
-		config.moduleTraversalDepthInternal = cliConfig.moduleTraversalDepthInternal;
+	// Assign "maxProjectImportDepth" setting from the CLI command (which overwrites tsconfig rules)
+	if (cliConfig.maxProjectImportDepth != null) {
+		config.maxProjectImportDepth = cliConfig.maxProjectImportDepth;
 	}
 
-	// Assign "moduleTraversalDepthExternal" setting from the CLI command (which overwrites tsconfig rules)
-	if (cliConfig.moduleTraversalDepthExternal != null) {
-		config.moduleTraversalDepthExternal = cliConfig.moduleTraversalDepthExternal;
+	// Assign "maxNodeModuleImportDepth" setting from the CLI command (which overwrites tsconfig rules)
+	if (cliConfig.maxNodeModuleImportDepth != null) {
+		config.maxNodeModuleImportDepth = cliConfig.maxNodeModuleImportDepth;
 	}
 
 	return config;

--- a/packages/lit-analyzer/src/cli/analyze-command.ts
+++ b/packages/lit-analyzer/src/cli/analyze-command.ts
@@ -193,5 +193,15 @@ function readLitAnalyzerConfigFromCliConfig(cliConfig: LitAnalyzerCliConfig): Pa
 		config.logging = cliConfig.debug ? "verbose" : "off";
 	}
 
+	// Assign "moduleTraversalDepthInternal" setting from the CLI command (which overwrites tsconfig rules)
+	if (cliConfig.moduleTraversalDepthInternal != null) {
+		config.moduleTraversalDepthInternal = cliConfig.moduleTraversalDepthInternal;
+	}
+
+	// Assign "moduleTraversalDepthExternal" setting from the CLI command (which overwrites tsconfig rules)
+	if (cliConfig.moduleTraversalDepthExternal != null) {
+		config.moduleTraversalDepthExternal = cliConfig.moduleTraversalDepthExternal;
+	}
+
 	return config;
 }

--- a/packages/lit-analyzer/src/cli/lit-analyzer-cli-config.ts
+++ b/packages/lit-analyzer/src/cli/lit-analyzer-cli-config.ts
@@ -13,6 +13,6 @@ export interface LitAnalyzerCliConfig {
 	strict?: boolean;
 	format?: FormatterFormat;
 	rules?: LitAnalyzerRules;
-	moduleTraversalDepthInternal?: number;
-	moduleTraversalDepthExternal?: number;
+	maxProjectImportDepth?: number;
+	maxNodeModuleImportDepth?: number;
 }

--- a/packages/lit-analyzer/src/cli/lit-analyzer-cli-config.ts
+++ b/packages/lit-analyzer/src/cli/lit-analyzer-cli-config.ts
@@ -13,4 +13,6 @@ export interface LitAnalyzerCliConfig {
 	strict?: boolean;
 	format?: FormatterFormat;
 	rules?: LitAnalyzerRules;
+	moduleTraversalDepthInternal?: number;
+	moduleTraversalDepthExternal?: number;
 }

--- a/packages/ts-lit-plugin/README.md
+++ b/packages/ts-lit-plugin/README.md
@@ -91,6 +91,8 @@ You can configure this plugin through your `tsconfig.json`.
 | `globalAttributes` | List of html attributes names that you expect to be present at all times. | `string[]` | |
 | `globalEvents` | List of event names that you expect to be present at all times | `string[]` | |
 | `customHtmlData` | This plugin supports the [custom vscode html data format](https://code.visualstudio.com/updates/v1_31#_html-and-css-custom-data-support) through this setting. | [Vscode Custom HTML Data Format](https://github.com/Microsoft/vscode-html-languageservice/blob/master/docs/customData.md). Supports arrays, objects and relative file paths | |
+| `maxProjectImportDepth` | Determines how many modules deep dependencies are followed to determine whether a custom element is available in the current file. When `-1` is used, dependencies will be followed infinitely deep. | `number` | `-1` |
+| `maxNodeModuleImportDepth` | Determines how many modules deep dependencies in __npm packages__ are followed to determine whether a custom element is available in the current file. When `-1` is used, dependencies in __npm packages__ will be followed infinitely deep.| `number` | `1` |
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)](#rules)
 

--- a/packages/vscode-lit-plugin/README.md
+++ b/packages/vscode-lit-plugin/README.md
@@ -667,6 +667,8 @@ You can configure this plugin by going to `VS Code Settings` > `Extension` > `li
 | `globalAttributes` | List of html attributes names that you expect to be present at all times. | `string[]` | |
 | `globalEvents` | List of event names that you expect to be present at all times | `string[]` | |
 | `customHtmlData` | This plugin supports the [custom vscode html data format](https://code.visualstudio.com/updates/v1_31#_html-and-css-custom-data-support) through this setting. | [Vscode Custom HTML Data Format](https://github.com/Microsoft/vscode-html-languageservice/blob/master/docs/customData.md). Supports arrays, objects and relative file paths | |
+| `maxProjectImportDepth` | Determines how many modules deep dependencies are followed to determine whether a custom element is available in the current file. When `-1` is used, dependencies will be followed infinitely deep. | `number` | `-1` |
+| `maxNodeModuleImportDepth` | Determines how many modules deep dependencies in __npm packages__ are followed to determine whether a custom element is available in the current file. When `-1` is used, dependencies in __npm packages__ will be followed infinitely deep.| `number` | `1` |
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)](#other-features)
 

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -92,6 +92,16 @@
 						"description": "Enable strict mode.",
 						"default": false
 					},
+					"lit-plugin.moduleTraversalDepthInternal": {
+						"type": "string",
+						"description": "Determines how many modules deep dependencies are followed to determine whether a custom element is available in the current file.",
+						"default": "Infinity"
+					},
+					"lit-plugin.moduleTraversalDepthExternal": {
+						"type": "string",
+						"description": "Determines how many modules deep dependencies in npm packages are followed to determine whether a custom element is available in the current file.",
+						"default": 1
+					},
 					"lit-plugin.securitySystem": {
 						"type": "string",
 						"description": "The lit-html security sanitization strategy to assume.",

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -92,13 +92,13 @@
 						"description": "Enable strict mode.",
 						"default": false
 					},
-					"lit-plugin.moduleTraversalDepthInternal": {
-						"type": "string",
+					"lit-plugin.maxProjectImportDepth": {
+						"type": "integer",
 						"description": "Determines how many modules deep dependencies are followed to determine whether a custom element is available in the current file.",
-						"default": "Infinity"
+						"default": -1
 					},
-					"lit-plugin.moduleTraversalDepthExternal": {
-						"type": "string",
+					"lit-plugin.maxNodeModuleImportDepth": {
+						"type": "integer",
 						"description": "Determines how many modules deep dependencies in npm packages are followed to determine whether a custom element is available in the current file.",
 						"default": 1
 					},

--- a/packages/vscode-lit-plugin/schemas/tsconfig.schema.json
+++ b/packages/vscode-lit-plugin/schemas/tsconfig.schema.json
@@ -29,6 +29,16 @@
 									"description": "Enable strict mode.",
 									"default": false
 								},
+								"moduleTraversalDepthInternal": {
+									"type": "string",
+									"description": "Determines how many modules deep dependencies are followed to determine whether a custom element is available in the current file.",
+									"default": "Infinity"
+								},
+								"moduleTraversalDepthExternal": {
+									"type": "string",
+									"description": "Determines how many modules deep dependencies in npm packages are followed to determine whether a custom element is available in the current file.",
+									"default": 1
+								},
 								"securitySystem": {
 									"type": "string",
 									"description": "The lit-html security sanitization strategy to assume.",

--- a/packages/vscode-lit-plugin/schemas/tsconfig.schema.json
+++ b/packages/vscode-lit-plugin/schemas/tsconfig.schema.json
@@ -29,13 +29,13 @@
 									"description": "Enable strict mode.",
 									"default": false
 								},
-								"moduleTraversalDepthInternal": {
-									"type": "string",
+								"maxProjectImportDepth": {
+									"type": "integer",
 									"description": "Determines how many modules deep dependencies are followed to determine whether a custom element is available in the current file.",
-									"default": "Infinity"
+									"default": -1
 								},
-								"moduleTraversalDepthExternal": {
-									"type": "string",
+								"maxNodeModuleImportDepth": {
+									"type": "integer",
 									"description": "Determines how many modules deep dependencies in npm packages are followed to determine whether a custom element is available in the current file.",
 									"default": 1
 								},

--- a/packages/vscode-lit-plugin/src/extension.ts
+++ b/packages/vscode-lit-plugin/src/extension.ts
@@ -111,11 +111,11 @@ function getConfig(): Partial<LitAnalyzerConfig> {
 	withConfigValue(config, "securitySystem", value => {
 		outConfig.securitySystem = value;
 	});
-	withConfigValue(config, "moduleTraversalDepthInternal", value => {
-		outConfig.moduleTraversalDepthInternal = value;
+	withConfigValue(config, "maxProjectImportDepth", value => {
+		outConfig.maxProjectImportDepth = value;
 	});
-	withConfigValue(config, "moduleTraversalDepthExternal", value => {
-		outConfig.moduleTraversalDepthExternal = value;
+	withConfigValue(config, "maxNodeModuleImportDepth", value => {
+		outConfig.maxNodeModuleImportDepth = value;
 	});
 	// Template tags
 	withConfigValue(config, "htmlTemplateTags", value => {

--- a/packages/vscode-lit-plugin/src/extension.ts
+++ b/packages/vscode-lit-plugin/src/extension.ts
@@ -111,7 +111,20 @@ function getConfig(): Partial<LitAnalyzerConfig> {
 	withConfigValue(config, "securitySystem", value => {
 		outConfig.securitySystem = value;
 	});
-
+	withConfigValue(config, "moduleTraversalDepthInternal", value => {
+		const castedValue = Number(value);
+		if (!(isNaN(castedValue) || castedValue === 0)) {
+			// cast successful.
+			outConfig.moduleTraversalDepthExternal = castedValue;
+		}
+	});
+	withConfigValue(config, "moduleTraversalDepthExternal", value => {
+		const castedValue = Number(value);
+		if (!(isNaN(castedValue) || castedValue === 0)) {
+			// cast successful.
+			outConfig.moduleTraversalDepthExternal = castedValue;
+		}
+	});
 	// Template tags
 	withConfigValue(config, "htmlTemplateTags", value => {
 		outConfig.htmlTemplateTags = value;

--- a/packages/vscode-lit-plugin/src/extension.ts
+++ b/packages/vscode-lit-plugin/src/extension.ts
@@ -112,18 +112,10 @@ function getConfig(): Partial<LitAnalyzerConfig> {
 		outConfig.securitySystem = value;
 	});
 	withConfigValue(config, "moduleTraversalDepthInternal", value => {
-		const castedValue = Number(value);
-		if (!(isNaN(castedValue) || castedValue === 0)) {
-			// cast successful.
-			outConfig.moduleTraversalDepthExternal = castedValue;
-		}
+		outConfig.moduleTraversalDepthInternal = value;
 	});
 	withConfigValue(config, "moduleTraversalDepthExternal", value => {
-		const castedValue = Number(value);
-		if (!(isNaN(castedValue) || castedValue === 0)) {
-			// cast successful.
-			outConfig.moduleTraversalDepthExternal = castedValue;
-		}
+		outConfig.moduleTraversalDepthExternal = value;
 	});
 	// Template tags
 	withConfigValue(config, "htmlTemplateTags", value => {


### PR DESCRIPTION
I made maxInternalDepth and maxExternalDepth configurable.
The values can now be set under the name "moduleTraversalDepthInternal" and "moduleTraversalDepthExternal" via CLI argument, tsconfig or VSCode setting.

The default values stayed the same ("moduleTraversalDepthInternal" defaults to Infinity and "moduleTraversalDepthExternal" defaults to one).

Handling the value Infinity in JSON is tricky since it is not supported by the JSON format.
I decided to allow string values and cast them to number when loading the config, so that the value Infinity can be represented with the string "Infinity".

I am not completely satisfied with the variable names and the descriptions. 
Please tell me what you think about them.
Once we have agreed on the variable names I will add documentation.