### PR TITLE
Improve codefix for 'no-missing-import' rule.

### DIFF
--- a/packages/lit-analyzer/src/rules/no-missing-import.ts
+++ b/packages/lit-analyzer/src/rules/no-missing-import.ts
@@ -66,7 +66,8 @@ export default rule;
 function getRelativePathForImport(fromFileName: string, toFileName: string): string {
 	const path = posix.relative(dirname(fromFileName), dirname(toFileName));
 	const filenameWithoutExt = basename(toFileName).replace(/\.[^/.]+$/, "");
-	const importPath = `./${path ? `${path}/` : ""}${filenameWithoutExt}`;
+	const prefix = path.startsWith("../") ? "" : "./";
+	const importPath = `${prefix}${path ? `${path}/` : ""}${filenameWithoutExt}`;
 	return importPath
 		.replace(/^.*node_modules\//, "")
 		.replace(/\.d$/, "")


### PR DESCRIPTION
When generating an import statement for a module further up the directory structure, an unnecessary `"./"` is prepended.
Currently, import statements like this are generated: `import "./../../foo-component"`.
With this change the generated statements look like this: `import "../../foo-component"`.