### PR TITLE
Workaround webstorm compatibility

### DIFF
--- a/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
+++ b/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
@@ -69,7 +69,7 @@ export const ALL_RULE_IDS = Object.keys(DEFAULT_RULES_SEVERITY).sort() as LitAna
 // The user should always use the "rule id" string.
 // Consider if this map should be manually maintained in the future.
 export const RULE_ID_CODE_MAP = ALL_RULE_IDS.reduce((acc, ruleId, i) => {
-	acc[ruleId] = i + 1;
+	acc[ruleId] = i + 1001;
 	return acc;
 }, {} as Record<LitAnalyzerRuleId, number>);
 

--- a/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
+++ b/packages/lit-analyzer/src/analyze/lit-analyzer-config.ts
@@ -69,7 +69,7 @@ export const ALL_RULE_IDS = Object.keys(DEFAULT_RULES_SEVERITY).sort() as LitAna
 // The user should always use the "rule id" string.
 // Consider if this map should be manually maintained in the future.
 export const RULE_ID_CODE_MAP = ALL_RULE_IDS.reduce((acc, ruleId, i) => {
-	acc[ruleId] = i + 1001;
+	acc[ruleId] = i + 2300;
 	return acc;
 }, {} as Record<LitAnalyzerRuleId, number>);
 

--- a/packages/lit-analyzer/src/analyze/lit-analyzer.ts
+++ b/packages/lit-analyzer/src/analyze/lit-analyzer.ts
@@ -3,7 +3,6 @@ import { ComponentAnalyzer } from "./component-analyzer/component-analyzer";
 import { LitCssDocumentAnalyzer } from "./document-analyzer/css/lit-css-document-analyzer";
 import { LitHtmlDocumentAnalyzer } from "./document-analyzer/html/lit-html-document-analyzer";
 import { renameLocationsForTagName } from "./document-analyzer/html/rename-locations/rename-locations-for-tag-name";
-import { RULE_ID_CODE_MAP } from "./lit-analyzer-config";
 import { LitAnalyzerContext } from "./lit-analyzer-context";
 import { CssDocument } from "./parse/document/text-document/css-document/css-document";
 import { HtmlDocument } from "./parse/document/text-document/html-document/html-document";
@@ -35,10 +34,6 @@ export class LitAnalyzer {
 		// Set the Typescript module
 		// I plan on removing this function, so only "context.ts" is used.
 		setTypescriptModule(context.ts);
-	}
-
-	getSupportedCodeFixes(): string[] {
-		return Object.values(RULE_ID_CODE_MAP).map(String);
 	}
 
 	getOutliningSpansInFile(file: SourceFile): LitOutliningSpan[] {

--- a/packages/ts-lit-plugin/src/decorate-language-service.ts
+++ b/packages/ts-lit-plugin/src/decorate-language-service.ts
@@ -2,7 +2,6 @@
 import { LanguageService } from "typescript";
 import { logger } from "./logger";
 import { TsLitPlugin } from "./ts-lit-plugin/ts-lit-plugin";
-import { tsModule } from "./ts-module";
 
 export function decorateLanguageService(languageService: LanguageService, plugin: TsLitPlugin): LanguageService {
 	const languageServiceExtension: Partial<LanguageService> = {
@@ -27,8 +26,8 @@ export function decorateLanguageService(languageService: LanguageService, plugin
 
 	// Decorate "getSupportedCodeFixes"
 	// Read more here: https://github.com/microsoft/TypeScript/issues/29051
-	const getSupportedCodeFixes = tsModule.ts.getSupportedCodeFixes.bind(tsModule.ts);
-	tsModule.ts.getSupportedCodeFixes = () => {
+	const getSupportedCodeFixes = plugin.context.ts.getSupportedCodeFixes.bind(plugin.context.ts);
+	plugin.context.ts.getSupportedCodeFixes = () => {
 		return [...getSupportedCodeFixes(), ...plugin.getSupportedCodeFixes()];
 	};
 

--- a/packages/ts-lit-plugin/src/decorate-language-service.ts
+++ b/packages/ts-lit-plugin/src/decorate-language-service.ts
@@ -24,13 +24,6 @@ export function decorateLanguageService(languageService: LanguageService, plugin
 		...languageServiceExtension
 	};
 
-	// Decorate "getSupportedCodeFixes"
-	// Read more here: https://github.com/microsoft/TypeScript/issues/29051
-	const getSupportedCodeFixes = plugin.context.ts.getSupportedCodeFixes.bind(plugin.context.ts);
-	plugin.context.ts.getSupportedCodeFixes = () => {
-		return [...getSupportedCodeFixes(), ...plugin.getSupportedCodeFixes()];
-	};
-
 	// Make sure to call the old service if config.disable === true
 	for (const methodName of Object.getOwnPropertyNames(languageServiceExtension) as (keyof LanguageService)[]) {
 		const newMethod: Function | undefined = decoratedLanguageService[methodName]!;

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/ts-lit-plugin.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/ts-lit-plugin.ts
@@ -42,10 +42,6 @@ export class TsLitPlugin {
 
 	constructor(private prevLangService: LanguageService, public readonly context: LitPluginContext) {}
 
-	getSupportedCodeFixes(): string[] {
-		return this.litAnalyzer.getSupportedCodeFixes();
-	}
-
 	getCompletionEntryDetails(
 		fileName: string,
 		position: number,


### PR DESCRIPTION
This is the workaround I mentioned in Issue #124.
The codes of `lit-analyzer`s rules now start at 2300 meaning that each code collides with [typescripts internal error codes](https://github.com/microsoft/TypeScript/blob/master/src/compiler/diagnosticMessages.json).

Because the given error codes are already allowed to create codeFixes, we dont need to patch `getSupportedCodeFixes` anymore. I tested this a bit and couldnt find anything that breaks when reusing the error codes.
I chose to start at 2300 since all codes are used without gaps until 2400 and dont appear to have changed since typescript 2.

@runem, let me know if this is a accaptable workaround to you, otherwise I will look into this further.

Fix #124