### PR TITLE
Implement fix for symlinked modules.

### DIFF
--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
@@ -72,6 +72,8 @@ export function parseAllIndirectImports(
 	visitIndirectImportsFromSourceFile(sourceFile, {
 		project: context.project,
 		program: context.program,
+		definitionStore: context.definitionStore,
+		htmlStore: context.htmlStore,
 		ts: context.ts,
 		directImportCache: DIRECT_IMPORT_CACHE,
 		maxExternalDepth: maxExternalDepth ?? context.config.maxNodeModuleImportDepth,

--- a/packages/lit-analyzer/src/analyze/store/analyzer-definition-store.ts
+++ b/packages/lit-analyzer/src/analyze/store/analyzer-definition-store.ts
@@ -7,4 +7,5 @@ export interface AnalyzerDefinitionStore {
 	getComponentDeclarationsInFile(sourceFile: SourceFile): ComponentDeclaration[];
 	getDefinitionForTagName(tagName: string): ComponentDefinition | undefined;
 	getDefinitionsInFile(sourceFile: SourceFile): ComponentDefinition[];
+	absorbAnalysisResult(sourceFile: SourceFile, result: AnalyzerResult): void;
 }

--- a/packages/lit-analyzer/src/analyze/store/analyzer-html-store.ts
+++ b/packages/lit-analyzer/src/analyze/store/analyzer-html-store.ts
@@ -7,7 +7,8 @@ import {
 	HtmlMember,
 	HtmlProp,
 	HtmlSlot,
-	HtmlTag
+	HtmlTag,
+	HtmlDataCollection
 } from "../parse/parse-html-data/html-tag";
 import {
 	HtmlNodeAttr,
@@ -17,6 +18,7 @@ import {
 	IHtmlNodeBooleanAttribute
 } from "../types/html-node/html-node-attr-types";
 import { HtmlNode } from "../types/html-node/html-node-types";
+import { HtmlDataSourceKind } from "./html-store/html-data-source-merged";
 
 export interface AnalyzerHtmlStore {
 	/*absorbAnalysisResult(sourceFile: SourceFile, result: AnalyzeComponentsResult): void;
@@ -28,7 +30,7 @@ export interface AnalyzerHtmlStore {
 	getDefinitionForTagName(tagName: string): ComponentDefinition | undefined;
 	getDefinitionsInFile(sourceFile: SourceFile): ComponentDefinition[];
 	hasTagNameBeenImported(fileName: string, tagName: string): boolean;*/
-
+	absorbCollection(collection: HtmlDataCollection, register: HtmlDataSourceKind): void;
 	getHtmlTag(htmlNode: HtmlNode | string): HtmlTag | undefined;
 	getGlobalTags(): Iterable<HtmlTag>;
 	getAllAttributesForTag(htmlNode: HtmlNode | string): Iterable<HtmlAttr>;

--- a/packages/lit-analyzer/src/analyze/util/symlink-util.ts
+++ b/packages/lit-analyzer/src/analyze/util/symlink-util.ts
@@ -1,0 +1,54 @@
+import { analyzeSourceFile } from "web-component-analyzer";
+import { SourceFile } from "typescript";
+import { convertAnalyzeResultToHtmlCollection } from "../parse/convert-component-definitions-to-html-collection";
+import { HtmlDataSourceKind } from "../store/html-store/html-data-source-merged";
+import { IVisitDependenciesContext } from "../parse/parse-dependencies/visit-dependencies";
+
+/**
+ * Gets Component Definitions in a symlinked file.
+ * @param file
+ * @param context
+ */
+export function findComponentDefinitionsInSymlinkedFile(file: SourceFile, context: IVisitDependenciesContext): void {
+	const { definitionStore, htmlStore, program, ts } = context;
+	const analyzeResult = analyzeSourceFile(file, {
+		program: program,
+		ts: ts,
+		config: {
+			features: ["event", "member", "slot", "csspart", "cssproperty"],
+			analyzeGlobalFeatures: true,
+			analyzeDefaultLib: true,
+			analyzeDependencies: true,
+			analyzeAllDeclarations: false,
+			excludedDeclarationNames: ["HTMLElement"]
+		}
+	});
+
+	definitionStore.absorbAnalysisResult(file, analyzeResult);
+	const htmlCollection = convertAnalyzeResultToHtmlCollection(analyzeResult, {
+		checker: program.getTypeChecker(),
+		addDeclarationPropertiesAsAttributes: program.isSourceFileFromExternalLibrary(file)
+	});
+
+	htmlStore.absorbCollection(htmlCollection, HtmlDataSourceKind.DECLARED);
+}
+
+/**
+ * Gets a symlinked SourceFile using the actual path of the symlinked
+ * file rather than the path that the symlink resolves to.
+ * @param originalPath
+ * @param project
+ */
+export function getSourceFileFromSymlinkedDependency(originalPath: string, project?: ts.server.Project): SourceFile | undefined {
+	if (project == null) return undefined;
+	const path = project.projectService.toPath(originalPath);
+	const normalizedPath: ts.server.NormalizedPath = (path as unknown) as ts.server.NormalizedPath;
+	const scriptInfo = project.projectService.getOrCreateScriptInfoForNormalizedPath(normalizedPath, false);
+	if (scriptInfo != null) {
+		if (!project.isRoot(scriptInfo)) {
+			project.addRoot(scriptInfo, scriptInfo.fileName);
+			project.updateGraph();
+		}
+	}
+	return project.getSourceFile(path);
+}


### PR DESCRIPTION
When using the analyzer in a project I had problems when using symlinked dependencies.
In the project I installed a component library as a symlinked dependecy using lerna.

The no-missing-import rule didn't work as expected in this situation.
1. The analyzer created a missing-import warning for every custom Element I used from this library (even though the required import statements were present).
2. When the required import statements were NOT present, the analyzer didn't supply the codefix to add them.

This behaviour occurs because the analyzer cannot follow symlinked dependencies that are out of the scope of the project.
With this PR symlinked dependencies can be followed. When a symlinked module is discovered in dependency traversal, the analyzer now uses the actual path of the symlinked module rather than the path that the symlink resolves to.

Any feedback is welcome.