### PR TITLE
Small refactorings.

### DIFF
--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
@@ -62,11 +62,7 @@ export function parseDependencies(sourceFile: SourceFile, context: LitAnalyzerCo
  * @param maxExternalDepth
  * @param minExternalDepth
  */
-export function parseAllIndirectImports(
-	sourceFile: SourceFile,
-	context: LitAnalyzerContext,
-	{ maxExternalDepth, maxInternalDepth }: { maxExternalDepth?: number; maxInternalDepth?: number } = {}
-): Set<SourceFile> {
+export function parseAllIndirectImports(sourceFile: SourceFile, context: LitAnalyzerContext): Set<SourceFile> {
 	const importedSourceFiles = new Set<SourceFile>();
 
 	visitIndirectImportsFromSourceFile(sourceFile, {
@@ -74,8 +70,7 @@ export function parseAllIndirectImports(
 		program: context.program,
 		ts: context.ts,
 		directImportCache: DIRECT_IMPORT_CACHE,
-		maxExternalDepth: maxExternalDepth ?? context.config.maxNodeModuleImportDepth,
-		maxInternalDepth: maxInternalDepth ?? context.config.maxProjectImportDepth,
+		config: context.config,
 		emitIndirectImport(file: SourceFile): boolean {
 			if (importedSourceFiles.has(file)) {
 				return false;

--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/parse-dependencies.ts
@@ -59,8 +59,6 @@ export function parseDependencies(sourceFile: SourceFile, context: LitAnalyzerCo
  * Returns a map of component declarations in each file encountered from a source file recursively.
  * @param sourceFile
  * @param context
- * @param maxExternalDepth
- * @param minExternalDepth
  */
 export function parseAllIndirectImports(sourceFile: SourceFile, context: LitAnalyzerContext): Set<SourceFile> {
 	const importedSourceFiles = new Set<SourceFile>();

--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -1,16 +1,16 @@
 import * as tsModule from "typescript";
 import { Node, Program, SourceFile } from "typescript";
+import { LitAnalyzerConfig } from "../../lit-analyzer-config";
 
 interface IVisitDependenciesContext {
 	program: Program;
 	ts: typeof tsModule;
 	project: ts.server.Project | undefined;
 	directImportCache: WeakMap<SourceFile, Set<SourceFile>>;
-	emitIndirectImport(file: SourceFile, importedFrom?: SourceFile): boolean;
+	emitIndirectImport(file: SourceFile): boolean;
 	emitDirectImport?(file: SourceFile): void;
 	depth?: number;
-	maxExternalDepth?: number;
-	maxInternalDepth?: number;
+	config: LitAnalyzerConfig;
 }
 
 /**
@@ -30,9 +30,9 @@ export function visitIndirectImportsFromSourceFile(sourceFile: SourceFile, conte
 	const inExternal = context.program.isSourceFileFromExternalLibrary(sourceFile);
 
 	// Check if we have traversed too deep
-	if (inExternal && currentDepth >= (context.maxExternalDepth ?? Infinity)) {
+	if (inExternal && currentDepth >= (context.config.maxNodeModuleImportDepth ?? Infinity)) {
 		return;
-	} else if (!inExternal && currentDepth >= (context.maxInternalDepth ?? Infinity)) {
+	} else if (!inExternal && currentDepth >= (context.config.maxProjectImportDepth ?? Infinity)) {
 		return;
 	}
 

--- a/packages/lit-analyzer/src/analyze/util/rule-fix-util.ts
+++ b/packages/lit-analyzer/src/analyze/util/rule-fix-util.ts
@@ -1,5 +1,5 @@
 import { InterfaceDeclaration, ModuleDeclaration, SourceFile } from "typescript";
-import { tsModule } from "../../../../ts-lit-plugin/src/ts-module";
+import { tsModule } from "../ts-module";
 import { LitCodeFix } from "../types/lit-code-fix";
 import { LitCodeFixAction } from "../types/lit-code-fix-action";
 import { RuleFix } from "../types/rule/rule-fix";

--- a/packages/lit-analyzer/test/parser/dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/test/parser/dependencies/parse-dependencies.ts
@@ -51,14 +51,17 @@ tsTest("Correctly follows all project-internal imports with (default) maxInterna
 	t.deepEqual(sortedFileNames, ["file1.ts", "file2.ts", "file3.ts", "file4.ts", "file5.ts"]);
 });
 
-tsTest("Correctly follows project-internal imports with maxInternalDepth=1", t => {
-	const { sourceFile, context } = prepareAnalyzer([
-		{ fileName: "file1.ts", text: `export class MyClass { }` },
-		{ fileName: "file2.ts", text: `import * from "file1";export class MyClass { }` },
-		{ fileName: "file3.ts", text: `import * from "file2";export class MyClass { }`, entry: true }
-	]);
+tsTest("Correctly follows project-internal imports with maxProjectImportDepth=1", t => {
+	const { sourceFile, context } = prepareAnalyzer(
+		[
+			{ fileName: "file1.ts", text: `export class MyClass { }` },
+			{ fileName: "file2.ts", text: `import * from "file1";export class MyClass { }` },
+			{ fileName: "file3.ts", text: `import * from "file2";export class MyClass { }`, entry: true }
+		],
+		{ maxProjectImportDepth: 1 }
+	);
 
-	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 1 });
+	const dependencies = parseAllIndirectImports(sourceFile, context);
 
 	const sortedFileNames = Array.from(dependencies)
 		.map(file => file.fileName)
@@ -67,18 +70,21 @@ tsTest("Correctly follows project-internal imports with maxInternalDepth=1", t =
 	t.deepEqual(sortedFileNames, ["file2.ts", "file3.ts"]);
 });
 
-tsTest("Correctly follows project-internal imports with maxInternalDepth=5", t => {
-	const { sourceFile, context } = prepareAnalyzer([
-		{ fileName: "file1.ts", text: `export class MyClass { }` },
-		{ fileName: "file2.ts", text: `import * from "file1";export class MyClass { }` },
-		{ fileName: "file3.ts", text: `import * from "file2";export class MyClass { }` },
-		{ fileName: "file4.ts", text: `import * from "file3";export class MyClass { }` },
-		{ fileName: "file5.ts", text: `import * from "file4";export class MyClass { }` },
-		{ fileName: "file6.ts", text: `import * from "file5";export class MyClass { }` },
-		{ fileName: "file7.ts", text: `import * from "file6";export class MyClass { }`, entry: true }
-	]);
+tsTest("Correctly follows project-internal imports with maxProjectImportDepth=5", t => {
+	const { sourceFile, context } = prepareAnalyzer(
+		[
+			{ fileName: "file1.ts", text: `export class MyClass { }` },
+			{ fileName: "file2.ts", text: `import * from "file1";export class MyClass { }` },
+			{ fileName: "file3.ts", text: `import * from "file2";export class MyClass { }` },
+			{ fileName: "file4.ts", text: `import * from "file3";export class MyClass { }` },
+			{ fileName: "file5.ts", text: `import * from "file4";export class MyClass { }` },
+			{ fileName: "file6.ts", text: `import * from "file5";export class MyClass { }` },
+			{ fileName: "file7.ts", text: `import * from "file6";export class MyClass { }`, entry: true }
+		],
+		{ maxProjectImportDepth: 5 }
+	);
 
-	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 5 });
+	const dependencies = parseAllIndirectImports(sourceFile, context);
 
 	const sortedFileNames = Array.from(dependencies)
 		.map(file => file.fileName)
@@ -87,14 +93,17 @@ tsTest("Correctly follows project-internal imports with maxInternalDepth=5", t =
 	t.deepEqual(sortedFileNames, ["file2.ts", "file3.ts", "file4.ts", "file5.ts", "file6.ts", "file7.ts"]);
 });
 
-tsTest("Correctly follows project-external imports with maxExternalDepth=1", t => {
-	const { sourceFile, context } = prepareAnalyzer([
-		{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
-		{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
-		{ fileName: "node_modules/file3.ts", text: `import * from "./file2";export class MyClass { }`, entry: true }
-	]);
+tsTest("Correctly follows project-external imports with maxNodeModuleImportDepth=1", t => {
+	const { sourceFile, context } = prepareAnalyzer(
+		[
+			{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
+			{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
+			{ fileName: "node_modules/file3.ts", text: `import * from "./file2";export class MyClass { }`, entry: true }
+		],
+		{ maxNodeModuleImportDepth: 1 }
+	);
 
-	const dependencies = parseAllIndirectImports(sourceFile, context, { maxExternalDepth: 1 });
+	const dependencies = parseAllIndirectImports(sourceFile, context);
 
 	const sortedFileNames = Array.from(dependencies)
 		.map(file => file.fileName)
@@ -103,18 +112,21 @@ tsTest("Correctly follows project-external imports with maxExternalDepth=1", t =
 	t.deepEqual(sortedFileNames, ["node_modules/file2.ts", "node_modules/file3.ts"]);
 });
 
-tsTest("Correctly follows project-external imports with maxExternalDepth=5", t => {
-	const { sourceFile, context } = prepareAnalyzer([
-		{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
-		{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
-		{ fileName: "node_modules/file3.ts", text: `import * from "./file2";export class MyClass { }` },
-		{ fileName: "node_modules/file4.ts", text: `import * from "./file3";export class MyClass { }` },
-		{ fileName: "node_modules/file5.ts", text: `import * from "./file4";export class MyClass { }` },
-		{ fileName: "node_modules/file6.ts", text: `import * from "./file5";export class MyClass { }` },
-		{ fileName: "node_modules/file7.ts", text: `import * from "./file6";export class MyClass { }`, entry: true }
-	]);
+tsTest("Correctly follows project-external imports with maxNodeModuleImportDepth=5", t => {
+	const { sourceFile, context } = prepareAnalyzer(
+		[
+			{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
+			{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
+			{ fileName: "node_modules/file3.ts", text: `import * from "./file2";export class MyClass { }` },
+			{ fileName: "node_modules/file4.ts", text: `import * from "./file3";export class MyClass { }` },
+			{ fileName: "node_modules/file5.ts", text: `import * from "./file4";export class MyClass { }` },
+			{ fileName: "node_modules/file6.ts", text: `import * from "./file5";export class MyClass { }` },
+			{ fileName: "node_modules/file7.ts", text: `import * from "./file6";export class MyClass { }`, entry: true }
+		],
+		{ maxNodeModuleImportDepth: 5 }
+	);
 
-	const dependencies = parseAllIndirectImports(sourceFile, context, { maxExternalDepth: 5 });
+	const dependencies = parseAllIndirectImports(sourceFile, context);
 
 	const sortedFileNames = Array.from(dependencies)
 		.map(file => file.fileName)
@@ -130,14 +142,17 @@ tsTest("Correctly follows project-external imports with maxExternalDepth=5", t =
 	]);
 });
 
-tsTest("Correctly resets depth when going from internal to external module with maxInternalDepth=1", t => {
-	const { sourceFile, context } = prepareAnalyzer([
-		{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
-		{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
-		{ fileName: "file3.ts", text: `import * from "./node_modules/file2";export class MyClass { }`, entry: true }
-	]);
+tsTest("Correctly resets depth when going from internal to external module with maxProjectImportDepth=1", t => {
+	const { sourceFile, context } = prepareAnalyzer(
+		[
+			{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
+			{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
+			{ fileName: "file3.ts", text: `import * from "./node_modules/file2";export class MyClass { }`, entry: true }
+		],
+		{ maxProjectImportDepth: 1 }
+	);
 
-	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 1 });
+	const dependencies = parseAllIndirectImports(sourceFile, context);
 
 	const sortedFileNames = Array.from(dependencies)
 		.map(file => file.fileName)
@@ -145,15 +160,18 @@ tsTest("Correctly resets depth when going from internal to external module with 
 	t.deepEqual(sortedFileNames, ["file3.ts", "node_modules/file2.ts"]);
 });
 
-tsTest("Correctly resets depth when going from internal to external module with maxInternalDepth=2", t => {
-	const { sourceFile, context } = prepareAnalyzer([
-		{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
-		{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
-		{ fileName: "file3.ts", text: `import * from "./node_modules/file2";export class MyClass { }` },
-		{ fileName: "file4.ts", text: `import * from "./file3";export class MyClass { }`, entry: true }
-	]);
+tsTest("Correctly resets depth when going from internal to external module with maxProjectImportDepth=2", t => {
+	const { sourceFile, context } = prepareAnalyzer(
+		[
+			{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
+			{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
+			{ fileName: "file3.ts", text: `import * from "./node_modules/file2";export class MyClass { }` },
+			{ fileName: "file4.ts", text: `import * from "./file3";export class MyClass { }`, entry: true }
+		],
+		{ maxProjectImportDepth: 2 }
+	);
 
-	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 2 });
+	const dependencies = parseAllIndirectImports(sourceFile, context);
 
 	const sortedFileNames = Array.from(dependencies)
 		.map(file => file.fileName)
@@ -163,14 +181,17 @@ tsTest("Correctly resets depth when going from internal to external module with 
 });
 
 tsTest("Correctly resets depth when going from internal to external module when first external module is a facade module", t => {
-	const { sourceFile, context } = prepareAnalyzer([
-		{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
-		{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
-		{ fileName: "node_modules/file3.ts", text: `import * from "./file2"` },
-		{ fileName: "file4.ts", text: `import * from "./node_modules/file3";export class MyClass { }`, entry: true }
-	]);
+	const { sourceFile, context } = prepareAnalyzer(
+		[
+			{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
+			{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
+			{ fileName: "node_modules/file3.ts", text: `import * from "./file2"` },
+			{ fileName: "file4.ts", text: `import * from "./node_modules/file3";export class MyClass { }`, entry: true }
+		],
+		{ maxProjectImportDepth: 1 }
+	);
 
-	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 1 });
+	const dependencies = parseAllIndirectImports(sourceFile, context);
 
 	const sortedFileNames = Array.from(dependencies)
 		.map(file => file.fileName)
@@ -180,15 +201,18 @@ tsTest("Correctly resets depth when going from internal to external module when 
 });
 
 tsTest("Correctly follows modules when going from internal to external module when second external module is a facade module", t => {
-	const { sourceFile, context } = prepareAnalyzer([
-		{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
-		{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
-		{ fileName: "node_modules/file3.ts", text: `import * from "./file2"` },
-		{ fileName: "node_modules/file4.ts", text: `import * from "./file3";export class MyClass { }` },
-		{ fileName: "file5.ts", text: `import * from "./node_modules/file4";export class MyClass { }`, entry: true }
-	]);
+	const { sourceFile, context } = prepareAnalyzer(
+		[
+			{ fileName: "node_modules/file1.ts", text: `export class MyClass { }` },
+			{ fileName: "node_modules/file2.ts", text: `import * from "./file1";export class MyClass { }` },
+			{ fileName: "node_modules/file3.ts", text: `import * from "./file2"` },
+			{ fileName: "node_modules/file4.ts", text: `import * from "./file3";export class MyClass { }` },
+			{ fileName: "file5.ts", text: `import * from "./node_modules/file4";export class MyClass { }`, entry: true }
+		],
+		{ maxProjectImportDepth: 1, maxNodeModuleImportDepth: 2 }
+	);
 
-	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 1, maxExternalDepth: 2 });
+	const dependencies = parseAllIndirectImports(sourceFile, context);
 
 	const sortedFileNames = Array.from(dependencies)
 		.map(file => file.fileName)
@@ -246,14 +270,17 @@ tsTest("Correctly identifies facade modules", t => {
 });
 
 tsTest("Correctly follows facade modules one level", t => {
-	const { sourceFile, context } = prepareAnalyzer([
-		{ fileName: "file1.ts", text: `export class MyClass { }` },
-		{ fileName: "file2.ts", text: `import * from "file1"; export class MyClass { }` },
-		{ fileName: "file3.ts", text: `import * from "file2";` },
-		{ fileName: "file4.ts", text: `import * from "file3"; export class MyClass { }"`, entry: true }
-	]);
+	const { sourceFile, context } = prepareAnalyzer(
+		[
+			{ fileName: "file1.ts", text: `export class MyClass { }` },
+			{ fileName: "file2.ts", text: `import * from "file1"; export class MyClass { }` },
+			{ fileName: "file3.ts", text: `import * from "file2";` },
+			{ fileName: "file4.ts", text: `import * from "file3"; export class MyClass { }"`, entry: true }
+		],
+		{ maxProjectImportDepth: 1 }
+	);
 
-	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 1 });
+	const dependencies = parseAllIndirectImports(sourceFile, context);
 
 	const sortedFileNames = Array.from(dependencies)
 		.map(file => file.fileName)
@@ -263,15 +290,18 @@ tsTest("Correctly follows facade modules one level", t => {
 });
 
 tsTest("Correctly follows facade modules multiple levels", t => {
-	const { sourceFile, context } = prepareAnalyzer([
-		{ fileName: "file0.ts", text: `export class MyClass { }` },
-		{ fileName: "file1.ts", text: `export * from "file0"; export class MyClass { }` },
-		{ fileName: "file2.ts", text: `export * from "file1";` },
-		{ fileName: "file3.ts", text: `import * from "file2";` },
-		{ fileName: "file4.ts", text: `import * from "file3"; export class MyClass { }"`, entry: true }
-	]);
+	const { sourceFile, context } = prepareAnalyzer(
+		[
+			{ fileName: "file0.ts", text: `export class MyClass { }` },
+			{ fileName: "file1.ts", text: `export * from "file0"; export class MyClass { }` },
+			{ fileName: "file2.ts", text: `export * from "file1";` },
+			{ fileName: "file3.ts", text: `import * from "file2";` },
+			{ fileName: "file4.ts", text: `import * from "file3"; export class MyClass { }"`, entry: true }
+		],
+		{ maxProjectImportDepth: 1 }
+	);
 
-	const dependencies = parseAllIndirectImports(sourceFile, context, { maxInternalDepth: 1 });
+	const dependencies = parseAllIndirectImports(sourceFile, context);
 
 	const sortedFileNames = Array.from(dependencies)
 		.map(file => file.fileName)


### PR DESCRIPTION
This PR consists of three small changes:
1. Remove unused [optional parameter](https://github.com/runem/lit-analyzer/pull/131/commits/916a363fcec28b8879674fa4bb8ec8ce9e75240f#diff-207d5eeabaefc8cd4eb5cceb87ba0db7L9) on emitIndirectImport.
2. [Read maxNodeModuleImportDepth and maxProjectImportDepth](https://github.com/runem/lit-analyzer/pull/131/commits/916a363fcec28b8879674fa4bb8ec8ce9e75240f#diff-d0ea9af083ee1fcfbcfd24a5b8cf228eL66-L69) from config rather than passing them to parseAllIndirectImports explicitly.
3. [Use lit-analyzers tsModule](https://github.com/runem/lit-analyzer/pull/131/commits/916a363fcec28b8879674fa4bb8ec8ce9e75240f#diff-0a6eadb8019f70c7b7f29f23bffcd427L2) inside lit-analyzer (ts-lit-plugins tsModule was used before).