### PR TITLE
lit-analyzer: ignore type-only imports

### DIFF
--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -109,7 +109,7 @@ function visitDirectImports(node: Node, context: IVisitDependenciesContext): voi
 	if (node == null) return;
 
 	// Handle top level imports/exports: (import "..."), (import { ... } from "..."), (export * from "...")
-	if (context.ts.isImportDeclaration(node) || context.ts.isExportDeclaration(node)) {
+	if ((context.ts.isImportDeclaration(node) && !node.importClause?.isTypeOnly) || context.ts.isExportDeclaration(node)) {
 		if (node.moduleSpecifier != null && context.ts.isStringLiteral(node.moduleSpecifier) && context.ts.isSourceFile(node.parent)) {
 			// Potentially ignore all imports/exports with named imports/exports because importing an interface would not
 			//    necessarily result in the custom element being defined. An even better solution would be to ignore all

--- a/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -109,7 +109,7 @@ function visitDirectImports(node: Node, context: IVisitDependenciesContext): voi
 	if (node == null) return;
 
 	// Handle top level imports/exports: (import "..."), (import { ... } from "..."), (export * from "...")
-	if ((context.ts.isImportDeclaration(node) && !node.importClause?.isTypeOnly) || context.ts.isExportDeclaration(node)) {
+	if ((context.ts.isImportDeclaration(node) && !node.importClause?.isTypeOnly) || (context.ts.isExportDeclaration(node) && !node.isTypeOnly)) {
 		if (node.moduleSpecifier != null && context.ts.isStringLiteral(node.moduleSpecifier) && context.ts.isSourceFile(node.parent)) {
 			// Potentially ignore all imports/exports with named imports/exports because importing an interface would not
 			//    necessarily result in the custom element being defined. An even better solution would be to ignore all

--- a/packages/lit-analyzer/test/parser/dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/test/parser/dependencies/parse-dependencies.ts
@@ -279,3 +279,24 @@ tsTest("Correctly follows facade modules multiple levels", t => {
 
 	t.deepEqual(sortedFileNames, ["file1.ts", "file2.ts", "file3.ts", "file4.ts"]);
 });
+
+tsTest("Ignores type-only imports in a file", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "file1.ts", text: `` },
+		{
+			fileName: "file2.ts",
+			text: `
+				import type { MyElement } from "./file1";
+			`,
+			entry: true
+		}
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context);
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["file2.ts"]);
+});

--- a/packages/lit-analyzer/test/parser/dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/test/parser/dependencies/parse-dependencies.ts
@@ -300,3 +300,24 @@ tsTest("Ignores type-only imports in a file", t => {
 
 	t.deepEqual(sortedFileNames, ["file2.ts"]);
 });
+
+tsTest("Ignores type-only exports in a file", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "file1.ts", text: `` },
+		{
+			fileName: "file2.ts",
+			text: `
+				export type { MyElement } from "./file1";
+			`,
+			entry: true
+		}
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context);
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["file2.ts"]);
+});


### PR DESCRIPTION
fixes #137.

this looks like it might be ok to sort the issue. let me know if you see anything wrong with it @runem 

i suppose the dependencies array contains the entry point always? and thats why i had to assert for it rather than `[]`?