### PR TITLE
lit-analyzer: account for string targets

### DIFF
--- a/packages/lit-analyzer/src/analyze/data/extra-html-data.ts
+++ b/packages/lit-analyzer/src/analyze/data/extra-html-data.ts
@@ -58,7 +58,7 @@ const HTML_5_ATTR_TYPES: { [key: string]: string | string[] | [string[]] } = {
 	title: "string",
 	manifest: "",
 	href: "string",
-	target: ["_blank", "_parent", "_self", "_top"],
+	target: "string|\"_blank\"|\"_parent\"|\"_self\"|\"_top\"",
 	rel: "",
 	media: "",
 	hreflang: "",

--- a/packages/lit-analyzer/src/analyze/data/extra-html-data.ts
+++ b/packages/lit-analyzer/src/analyze/data/extra-html-data.ts
@@ -58,7 +58,7 @@ const HTML_5_ATTR_TYPES: { [key: string]: string | string[] | [string[]] } = {
 	title: "string",
 	manifest: "",
 	href: "string",
-	target: "string|\"_blank\"|\"_parent\"|\"_self\"|\"_top\"",
+	target: 'string|"_blank"|"_parent"|"_self"|"_top"',
 	rel: "",
 	media: "",
 	hreflang: "",

--- a/packages/lit-analyzer/test/rules/no-incompatible-type-binding.ts
+++ b/packages/lit-analyzer/test/rules/no-incompatible-type-binding.ts
@@ -224,3 +224,10 @@ html\`<input step="\${myDirective("foo")}" /> \`
 
 	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
 });
+
+tsTest("Attribute binding: the target attribute is correctly type checked when given a string", t => {
+	const { diagnostics } = getDiagnostics(`html\`<a target="custom-target"></a>\`
+	`);
+
+	hasNoDiagnostics(t, diagnostics);
+});


### PR DESCRIPTION
Part of #165 

A target of a link can actually be any valid string as well as the special cases.

> Otherwise, a new browsing context is being requested, and what happens depends on the user agent’s configuration and abilities — it is determined by the rules given for the first applicable option from the following list:

from here:
https://www.w3.org/TR/html52/browsers.html#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name