### PR TITLE
update vscode dependency to fix ci builds

### DIFF
--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -36,7 +36,7 @@
 	"dependencies": {
 		"lit-html": "https://github.com/mjbvz/vscode-lit-html.git#1.11.1",
 		"ts-lit-plugin": "1.2.1",
-		"vscode-styled-components": "https://github.com/styled-components/vscode-styled-components#4320c223666ea835e8c63c85573c2704f550b7df",
+		"vscode-styled-components": "https://github.com/styled-components/vscode-styled-components#v1.4.0",
 		"web-component-analyzer": "~1.1.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
At some point vscode pushed an update whereby the vscode package (or some related package) no longer exists at a URL it used to initialise/download from.

We don't actually depend directly on any vscode-related stuff so i guessed it was this vscode-styled-components dependency.

Annoyingly, we can't depend on the latest version of it because they introduced a husky hook which fails for us (it looks for `.git` directory while in a subdir). We even tell npm not to run scripts but it still does 🤷 