### PR TITLE
feat(directives): Recognize lit 2 directives

### DIFF
--- a/packages/lit-analyzer/src/rules/util/directive/get-directive.ts
+++ b/packages/lit-analyzer/src/rules/util/directive/get-directive.ts
@@ -134,7 +134,7 @@ export function getDirective(assignment: HtmlNodeAttrAssignment, context: RuleMo
 						// Factories can mark which parameters might be assigned to the property with the generic type in DirectiveFn<T>
 						// Here we get the actual type of the directive if the it is a generic directive with type. Example: DirectiveFn<string>
 						// Read more: https://github.com/Polymer/lit-html/pull/1151
-						// TODO: Implement this for Lit 2 DirectiveResult
+						// TODO: Implement this for Lit 2 DirectiveResult<typeof Class>
 						const actualType =
 							typeB.kind === "GENERIC_ARGUMENTS" && typeB.target.name === "DirectiveFn" && typeB.typeArguments.length > 0 // && typeB.typeArguments[0].kind !== "UNKNOWN"
 								? () => typeB.typeArguments[0]

--- a/packages/lit-analyzer/src/rules/util/directive/get-directive.ts
+++ b/packages/lit-analyzer/src/rules/util/directive/get-directive.ts
@@ -134,6 +134,7 @@ export function getDirective(assignment: HtmlNodeAttrAssignment, context: RuleMo
 						// Factories can mark which parameters might be assigned to the property with the generic type in DirectiveFn<T>
 						// Here we get the actual type of the directive if the it is a generic directive with type. Example: DirectiveFn<string>
 						// Read more: https://github.com/Polymer/lit-html/pull/1151
+						// TODO: Implement this for Lit 2 DirectiveResult
 						const actualType =
 							typeB.kind === "GENERIC_ARGUMENTS" && typeB.target.name === "DirectiveFn" && typeB.typeArguments.length > 0 // && typeB.typeArguments[0].kind !== "UNKNOWN"
 								? () => typeB.typeArguments[0]

--- a/packages/lit-analyzer/src/rules/util/directive/is-lit-directive.ts
+++ b/packages/lit-analyzer/src/rules/util/directive/is-lit-directive.ts
@@ -23,26 +23,19 @@ export function isLitDirective(type: SimpleType): boolean {
 		case "OBJECT":
 			return type.call != null && isLitDirective(type.call);
 		case "FUNCTION": {
-			// We expect a directive to be a function with at least one argument that
-			// returns void (Lit 1) or a DirectiveResult<type> (Lit 2).
+			// (Lit 1) We expect a directive to be a function with at least one
+			// argument that returns void.
 			if (
 				type.kind !== "FUNCTION" ||
 				type.parameters == null ||
 				type.parameters.length === 0 ||
 				type.returnType == null ||
-				(type.returnType.kind !== "VOID" && type.returnType.name !== "DirectiveResult")
+				type.returnType.kind !== "VOID"
 			) {
 				return false;
 			}
 
-			const isLit2Directive = type.returnType.name === "DirectiveResult";
-
-			// No further inferencing needed for Lit 2
-			if (isLit2Directive) {
-				return true;
-			}
-
-			// (Lit 1) And that one argument must all be lit Part types.
+			// And that one argument must all be lit Part types.
 			const firstArg = type.parameters[0].type;
 			if (firstArg.kind === "UNION") {
 				return firstArg.types.every(t => partTypeNames.has(t.name));

--- a/packages/lit-analyzer/test/rules/no-incompatible-type-binding.ts
+++ b/packages/lit-analyzer/test/rules/no-incompatible-type-binding.ts
@@ -120,9 +120,9 @@ tsTest("Attribute binding: Union of 'string | Directive' type expression is assi
 	hasNoDiagnostics(t, diagnostics);
 });
 
-tsTest("Attribute binding: Union of 'string | (a: number) => DirectiveResult' type expression is assignable to string", t => {
+tsTest("Attribute binding: Union of 'string | DirectiveResult' type expression is assignable to string", t => {
 	const { diagnostics } = getDiagnostics(
-		'class Directive {};interface DirectiveClass {new (part: Object): Directive;}interface DirectiveResult<T extends DirectiveClass = DirectiveClass>{}; html`<input placeholder="${{} as (a: number) => DirectiveResult)}" />`'
+		'class Directive {};interface DirectiveClass {new (part: Object): Directive;}interface DirectiveResult<T extends DirectiveClass = DirectiveClass>{}; html`<input placeholder="${{} as string | DirectiveResult}" />`'
 	);
 	hasNoDiagnostics(t, diagnostics);
 });

--- a/packages/lit-analyzer/test/rules/no-incompatible-type-binding.ts
+++ b/packages/lit-analyzer/test/rules/no-incompatible-type-binding.ts
@@ -120,6 +120,13 @@ tsTest("Attribute binding: Union of 'string | Directive' type expression is assi
 	hasNoDiagnostics(t, diagnostics);
 });
 
+tsTest("Attribute binding: Union of 'string | (a: number) => DirectiveResult' type expression is assignable to string", t => {
+	const { diagnostics } = getDiagnostics(
+		'class Directive {};interface DirectiveClass {new (part: Object): Directive;}interface DirectiveResult<T extends DirectiveClass = DirectiveClass>{}; html`<input placeholder="${{} as (a: number) => DirectiveResult)}" />`'
+	);
+	hasNoDiagnostics(t, diagnostics);
+});
+
 tsTest("Boolean binding: Empty string literal is not assignable in a boolean attribute binding", t => {
 	const { diagnostics } = getDiagnostics('html`<input ?required="${""}" />`');
 	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
@@ -178,12 +185,16 @@ tsTest("Attribute binding: 'guard' directive correctly infers correct type from 
 tsTest("Attribute binding: using custom directive won't result in diagnostics", t => {
 	const { diagnostics } = getDiagnostics(`
 export interface Part { }
+export interface DirectiveResult<T = unknown> {}
 
 const ifDefined: (value: unknown) => (part: Part) => void
+const ifDefinedLit2: (value: unknown) => DirectiveResult;
 
 const ifExists = (value: any) => ifDefined(value === null ? undefined : value);
+const ifExistsLit2 = (value: any) => ifDefinedLit2(value === null ? undefined : value);
 
 html\`<input step="\${ifExists(10)}" />\`
+html\`<input step="\${ifExistsLit2(10)}" />\`
 	`);
 	hasNoDiagnostics(t, diagnostics);
 });
@@ -209,6 +220,7 @@ const ${name} = {} as (<T>(arg: T) => DirectiveFn<T>);
 `;
 }
 
+// Currently no Lit 2 directive value inference
 tsTest("Attribute binding: correctly infers type of generic directive function", t => {
 	const { diagnostics } = getDiagnostics(`${makeCustomDirective("myDirective")}
 html\`<input step="\${myDirective(10)}" /> \`
@@ -217,6 +229,7 @@ html\`<input step="\${myDirective(10)}" /> \`
 	hasNoDiagnostics(t, diagnostics);
 });
 
+// Currently no Lit 2 directive value inference
 tsTest("Attribute binding: correctly infers type of generic directive function and fails type checking", t => {
 	const { diagnostics } = getDiagnostics(`${makeCustomDirective("myDirective")}
 html\`<input step="\${myDirective("foo")}" /> \`


### PR DESCRIPTION
Lit 2 the signature of the directive function is not `directive<T extends typeof DirectiveClass>(T) => DirectiveResult<T>`

This PR adds recognition of lit 2 directives but currently does not implement value inferencing, though it should be possible since it's just the return type of the `render` function of `T`

Related #141