### PR TITLE
[lit-analyzer] remove circular analyzer dependency

### DIFF
--- a/packages/lit-analyzer/src/analyze/util/rule-fix-util.ts
+++ b/packages/lit-analyzer/src/analyze/util/rule-fix-util.ts
@@ -1,5 +1,5 @@
 import { InterfaceDeclaration, ModuleDeclaration, SourceFile } from "typescript";
-import { tsModule } from "../../../../ts-lit-plugin/src/ts-module";
+import { tsModule } from "../ts-module";
 import { LitCodeFix } from "../types/lit-code-fix";
 import { LitCodeFixAction } from "../types/lit-code-fix-action";
 import { RuleFix } from "../types/rule/rule-fix";


### PR DESCRIPTION
Fixes #173 

Seems it may have just been a typo or something. This will allow us to drop rollup eventually