### PR TITLE
aria-haspopup no-incompatible-type-binding false alarm

### DIFF
--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -45,8 +45,8 @@
 		"fast-glob": "^2.2.6",
 		"parse5": "5.1.0",
 		"ts-simple-type": "~1.0.5",
-		"vscode-css-languageservice": "4.3.0",
-		"vscode-html-languageservice": "3.1.0",
+		"vscode-css-languageservice": "4.4.0",
+		"vscode-html-languageservice": "3.2.0",
 		"web-component-analyzer": "~1.1.1"
 	},
 	"devDependencies": {
@@ -67,7 +67,7 @@
 		"typescript-3.7": "npm:typescript@~3.7.4",
 		"typescript-3.8": "npm:typescript@~3.8.3",
 		"typescript-3.9": "npm:typescript@~3.9.3",
-		"vscode-web-custom-data": "0.3.0"
+		"vscode-web-custom-data": "0.3.4"
 	},
 	"ava": {
 		"cache": true,

--- a/packages/lit-analyzer/test/rules/no-incompatible-type-binding.ts
+++ b/packages/lit-analyzer/test/rules/no-incompatible-type-binding.ts
@@ -115,6 +115,16 @@ tsTest("Attribute binding: Boolean type expression (false) is assignable to 'tru
 	hasNoDiagnostics(t, diagnostics);
 });
 
+tsTest("Attribute binding: Non boolean expression (dialog) is assignable to aria-haspopup", t => {
+	const { diagnostics } = getDiagnostics('html`<input aria-haspopup="dialog" />`', { rules: { "no-boolean-in-attribute-binding": false } });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("Attribute binding: Random string literal is not assignable to aria-haspopup", t => {
+	const { diagnostics } = getDiagnostics('html`<input aria-haspopup="test" />`', { rules: { "no-boolean-in-attribute-binding": false } });
+	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
+});
+
 tsTest("Attribute binding: Union of 'string | Directive' type expression is assignable to string", t => {
 	const { diagnostics } = getDiagnostics('type DirectiveFn = {}; html`<input placeholder="${{} as string | DirectiveFn}" />`');
 	hasNoDiagnostics(t, diagnostics);


### PR DESCRIPTION
Fixes #142 

* Updated underlying vscode-web-customdata that exposes the type for aria-haspopup.
* Added test to make sure setting a non-boolean value is correct.