### PR TITLE
Add support for Lit 2 element expressions

### DIFF
--- a/packages/lit-analyzer/src/lib/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-attr-assignment.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-attr-assignment.ts
@@ -28,7 +28,7 @@ export function parseHtmlAttrAssignment(
 			// in HTML. The parts will be in the range of the attribute name instead.
 			const values = context.getPartsAtOffsetRange(htmlAttr.location);
 			return {
-				kind: HtmlNodeAttrAssignmentKind.ELEMENT,
+				kind: HtmlNodeAttrAssignmentKind.ELEMENT_EXPRESSION,
 				htmlAttr,
 				location: htmlAttr.location,
 				expression: values[0] as Expression

--- a/packages/lit-analyzer/src/lib/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-attr-assignment.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-attr-assignment.ts
@@ -1,3 +1,4 @@
+import { Expression } from "typescript";
 import { HtmlNodeAttrAssignment, HtmlNodeAttrAssignmentKind } from "../../../../../types/html-node/html-node-attr-assignment-types.js";
 import { HtmlNodeAttr } from "../../../../../types/html-node/html-node-attr-types.js";
 import { Range } from "../../../../../types/range.js";
@@ -20,6 +21,19 @@ export function parseHtmlAttrAssignment(
 	const location = getAssignmentLocation(p5Node, p5Attr, htmlAttr, context);
 
 	if (location == null) {
+		// A null assignment location might be an element expression, which only
+		// has an attribute name and no attribute "assignment".
+		if (htmlAttr.name.match(/_+\d+_/)) {
+			// Here we have an element expression, which doesn't have an "assignment"
+			// in HTML. The parts will be in the range of the attribute name instead.
+			const values = context.getPartsAtOffsetRange(htmlAttr.location);
+			return {
+				kind: HtmlNodeAttrAssignmentKind.ELEMENT,
+				htmlAttr,
+				location: htmlAttr.location,
+				expression: values[0] as Expression
+			};
+		}
 		return { kind: HtmlNodeAttrAssignmentKind.BOOLEAN, htmlAttr };
 	}
 

--- a/packages/lit-analyzer/src/lib/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-attr-assignment.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-attr-assignment.ts
@@ -23,7 +23,7 @@ export function parseHtmlAttrAssignment(
 	if (location == null) {
 		// A null assignment location might be an element expression, which only
 		// has an attribute name and no attribute "assignment".
-		if (htmlAttr.name.match(/_+\d+_/)) {
+		if (htmlAttr.name.match(/_+[0-9a-zA-Z]+_/)) {
 			// Here we have an element expression, which doesn't have an "assignment"
 			// in HTML. The parts will be in the range of the attribute name instead.
 			const values = context.getPartsAtOffsetRange(htmlAttr.location);

--- a/packages/lit-analyzer/src/lib/analyze/parse/document/virtual-document/virtual-ast-document.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/document/virtual-document/virtual-ast-document.ts
@@ -29,7 +29,8 @@ export class VirtualAstDocument implements VirtualDocument {
 					prevPart = part;
 				} else {
 					const length = getPartLength(part) + 3;
-					const substitution = this.substituteExpression(length, part, prevPart, this.parts[i + 1] as string);
+					const expressionIndex = (i - 1) / 2;
+					const substitution = this.substituteExpression(length, part, prevPart, this.parts[i + 1] as string, expressionIndex);
 					str += substitution;
 				}
 			});
@@ -129,8 +130,15 @@ export class VirtualAstDocument implements VirtualDocument {
 		}
 	}
 
-	protected substituteExpression(length: number, expression: Expression, prev: string, next: string | undefined): string {
-		return "_".repeat(length);
+	protected substituteExpression(length: number, expression: Expression, prev: string, next: string | undefined, index: number): string {
+		if (length < 4) {
+			throw new Error("Unexpected expression length: " + length);
+		}
+		const indexString = index + "";
+		if (indexString.length > length - 2) {
+			throw new Error("Too many expressions in this template: " + indexString);
+		}
+		return "_".repeat(length - indexString.length - 1) + indexString + "_";
 	}
 }
 

--- a/packages/lit-analyzer/src/lib/analyze/parse/document/virtual-document/virtual-ast-document.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/document/virtual-document/virtual-ast-document.ts
@@ -132,12 +132,14 @@ export class VirtualAstDocument implements VirtualDocument {
 
 	protected substituteExpression(length: number, expression: Expression, prev: string, next: string | undefined, index: number): string {
 		if (length < 4) {
-			throw new Error("Unexpected expression length: " + length);
+			throw new Error("Internal error: unexpected expression length: " + length);
 		}
 		const indexString = index + "";
 		if (indexString.length > length - 2) {
 			throw new Error("Too many expressions in this template: " + indexString);
 		}
+		// To support element expressions, where we substitute into attribute name
+		// position, we create a unique substitution by using the expression index
 		return "_".repeat(length - indexString.length - 1) + indexString + "_";
 	}
 }

--- a/packages/lit-analyzer/src/lib/analyze/parse/document/virtual-document/virtual-ast-document.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/document/virtual-document/virtual-ast-document.ts
@@ -134,12 +134,25 @@ export class VirtualAstDocument implements VirtualDocument {
 		if (length < 4) {
 			throw new Error("Internal error: unexpected expression length: " + length);
 		}
-		const indexString = index + "";
+		const indexString = index.toString(36);
 		if (indexString.length > length - 2) {
 			throw new Error("Too many expressions in this template: " + indexString);
 		}
 		// To support element expressions, where we substitute into attribute name
 		// position, we create a unique substitution by using the expression index
+		//
+		// We need this substitution to be valid in HTML for all valid lit-html
+		// expression positions - so it must be a valid unquoted attribute value,
+		// attribute name, and text content. Ideally the substitution would also
+		// be a valid tag name to support some analysis of Lit 2 static templates.
+		//
+		// Example substitution:
+		//
+		//     html`<a href=${u}>${text}</a>`
+		//
+		// becomes:
+		//
+		//     html`<a href=__0_>_____1_</a>`
 		return "_".repeat(length - indexString.length - 1) + indexString + "_";
 	}
 }

--- a/packages/lit-analyzer/src/lib/analyze/parse/document/virtual-document/virtual-css-document.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/document/virtual-document/virtual-css-document.ts
@@ -2,7 +2,7 @@ import { Expression } from "typescript";
 import { VirtualAstDocument } from "./virtual-ast-document.js";
 
 export class VirtualAstCssDocument extends VirtualAstDocument {
-	protected substituteExpression(length: number, expression: Expression, prev: string, next: string | undefined): string {
+	protected substituteExpression(length: number, expression: Expression, prev: string, next: string | undefined, _index: number): string {
 		const hasLeftColon = prev.match(/:[^;{]*\${$/) != null;
 		const hasRightColon = next != null && next.match(/^}\s*:\s+/) != null;
 		const hasRightSemicolon = next != null && next.match(/^}\s*;/) != null;

--- a/packages/lit-analyzer/src/lib/analyze/parse/document/virtual-document/virtual-html-document.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/document/virtual-document/virtual-html-document.ts
@@ -1,8 +1,3 @@
-import { Expression } from "typescript";
 import { VirtualAstDocument } from "./virtual-ast-document.js";
 
-export class VirtualAstHtmlDocument extends VirtualAstDocument {
-	protected substituteExpression(length: number, expression: Expression): string {
-		return "_".repeat(length);
-	}
-}
+export class VirtualAstHtmlDocument extends VirtualAstDocument {}

--- a/packages/lit-analyzer/src/lib/analyze/types/html-node/html-node-attr-assignment-types.ts
+++ b/packages/lit-analyzer/src/lib/analyze/types/html-node/html-node-attr-assignment-types.ts
@@ -6,7 +6,8 @@ export enum HtmlNodeAttrAssignmentKind {
 	BOOLEAN = "BOOLEAN",
 	EXPRESSION = "EXPRESSION",
 	STRING = "STRING",
-	MIXED = "MIXED"
+	MIXED = "MIXED",
+	ELEMENT = "ELEMENT"
 }
 
 export interface IHtmlNodeAttrAssignmentBase {
@@ -17,6 +18,11 @@ export interface IHtmlNodeAttrAssignmentBase {
 export interface IHtmlNodeAttrAssignmentExpression extends IHtmlNodeAttrAssignmentBase {
 	kind: HtmlNodeAttrAssignmentKind.EXPRESSION;
 	location: Range;
+	expression: Expression;
+}
+
+export interface IHtmlNodeAttrAssignmentElement extends IHtmlNodeAttrAssignmentBase {
+	kind: HtmlNodeAttrAssignmentKind.ELEMENT;
 	expression: Expression;
 }
 
@@ -40,4 +46,5 @@ export type HtmlNodeAttrAssignment =
 	| IHtmlNodeAttrAssignmentBoolean
 	| IHtmlNodeAttrAssignmentExpression
 	| IHtmlNodeAttrAssignmentString
-	| IHtmlNodeAttrAssignmentMixed;
+	| IHtmlNodeAttrAssignmentMixed
+	| IHtmlNodeAttrAssignmentElement;

--- a/packages/lit-analyzer/src/lib/analyze/types/html-node/html-node-attr-assignment-types.ts
+++ b/packages/lit-analyzer/src/lib/analyze/types/html-node/html-node-attr-assignment-types.ts
@@ -7,7 +7,7 @@ export enum HtmlNodeAttrAssignmentKind {
 	EXPRESSION = "EXPRESSION",
 	STRING = "STRING",
 	MIXED = "MIXED",
-	ELEMENT = "ELEMENT"
+	ELEMENT_EXPRESSION = "ELEMENT_EXPRESSION"
 }
 
 export interface IHtmlNodeAttrAssignmentBase {
@@ -22,7 +22,7 @@ export interface IHtmlNodeAttrAssignmentExpression extends IHtmlNodeAttrAssignme
 }
 
 export interface IHtmlNodeAttrAssignmentElement extends IHtmlNodeAttrAssignmentBase {
-	kind: HtmlNodeAttrAssignmentKind.ELEMENT;
+	kind: HtmlNodeAttrAssignmentKind.ELEMENT_EXPRESSION;
 	expression: Expression;
 }
 

--- a/packages/lit-analyzer/src/lib/rules/no-complex-attribute-binding.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-complex-attribute-binding.ts
@@ -1,4 +1,5 @@
 import { isAssignableToPrimitiveType, typeToString } from "ts-simple-type";
+import { HtmlNodeAttrAssignmentKind } from "../analyze/types/html-node/html-node-attr-assignment-types.js";
 import { HtmlNodeAttrKind } from "../analyze/types/html-node/html-node-attr-types.js";
 import { RuleModule } from "../analyze/types/rule/rule-module.js";
 import { rangeFromHtmlNodeAttr } from "../analyze/util/range-util.js";
@@ -18,6 +19,9 @@ const rule: RuleModule = {
 		// Only validate attribute bindings, because you are able to assign complex types in property bindings.
 		const { htmlAttr } = assignment;
 		if (htmlAttr.kind !== HtmlNodeAttrKind.ATTRIBUTE) return;
+
+		// Ignore element expressions
+		if (assignment.kind === HtmlNodeAttrAssignmentKind.ELEMENT_EXPRESSION) return;
 
 		const { typeA, typeB } = extractBindingTypes(assignment, context);
 

--- a/packages/lit-analyzer/src/lib/rules/no-incompatible-type-binding.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-incompatible-type-binding.ts
@@ -22,7 +22,7 @@ const rule: RuleModule = {
 	visitHtmlAssignment(assignment, context) {
 		const { htmlAttr } = assignment;
 
-		if (assignment.kind === HtmlNodeAttrAssignmentKind.ELEMENT) {
+		if (assignment.kind === HtmlNodeAttrAssignmentKind.ELEMENT_EXPRESSION) {
 			// For element bindings we only care about the expression type
 			const { typeB } = extractBindingTypes(assignment, context);
 			isAssignableInElementBinding(htmlAttr, typeB, context);

--- a/packages/lit-analyzer/src/lib/rules/no-incompatible-type-binding.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-incompatible-type-binding.ts
@@ -3,11 +3,13 @@ import {
 	LIT_HTML_EVENT_LISTENER_ATTRIBUTE_MODIFIER,
 	LIT_HTML_PROP_ATTRIBUTE_MODIFIER
 } from "../analyze/constants.js";
+import { HtmlNodeAttrAssignmentKind } from "../analyze/types/html-node/html-node-attr-assignment-types.js";
 import { RuleModule } from "../analyze/types/rule/rule-module.js";
 import { extractBindingTypes } from "./util/type/extract-binding-types.js";
 import { isAssignableInAttributeBinding } from "./util/type/is-assignable-in-attribute-binding.js";
 import { isAssignableInBooleanBinding } from "./util/type/is-assignable-in-boolean-binding.js";
 import { isAssignableInPropertyBinding } from "./util/type/is-assignable-in-property-binding.js";
+import { isAssignableInElementBinding } from "./util/type/is-assignable-in-element-binding.js";
 
 /**
  * This rule validate if the types of a binding are assignable.
@@ -20,7 +22,13 @@ const rule: RuleModule = {
 	visitHtmlAssignment(assignment, context) {
 		const { htmlAttr } = assignment;
 
-		if (context.htmlStore.getHtmlAttrTarget(assignment.htmlAttr) == null) {
+		if (assignment.kind === HtmlNodeAttrAssignmentKind.ELEMENT) {
+			// For element bindings we only care about the expression type
+			const { typeB } = extractBindingTypes(assignment, context);
+			isAssignableInElementBinding(htmlAttr, typeB, context);
+		}
+
+		if (context.htmlStore.getHtmlAttrTarget(htmlAttr) == null) {
 			return;
 		}
 

--- a/packages/lit-analyzer/src/lib/rules/no-unknown-attribute.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-unknown-attribute.ts
@@ -1,6 +1,7 @@
 import { LitAnalyzerConfig } from "../analyze/lit-analyzer-config.js";
 import { HtmlTag, litAttributeModifierForTarget } from "../analyze/parse/parse-html-data/html-tag.js";
 import { AnalyzerDefinitionStore } from "../analyze/store/analyzer-definition-store.js";
+import { HtmlNodeAttrAssignmentKind } from "../analyze/types/html-node/html-node-attr-assignment-types.js";
 import { HtmlNodeAttrKind } from "../analyze/types/html-node/html-node-attr-types.js";
 import { HtmlNodeKind } from "../analyze/types/html-node/html-node-types.js";
 import { RuleFix } from "../analyze/types/rule/rule-fix.js";
@@ -34,6 +35,9 @@ const rule: RuleModule = {
 
 			// Ignore unknown "data-" attributes
 			if (htmlAttr.name.startsWith("data-")) return;
+
+			// Ignore element expressions
+			if (htmlAttr.assignment?.kind === HtmlNodeAttrAssignmentKind.ELEMENT_EXPRESSION) return;
 
 			// Get suggested target
 			const suggestedTarget = suggestTargetForHtmlAttr(htmlAttr, htmlStore);

--- a/packages/lit-analyzer/src/lib/rules/util/type/extract-binding-types.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/type/extract-binding-types.ts
@@ -63,6 +63,8 @@ export function inferTypeFromAssignment(assignment: HtmlNodeAttrAssignment, chec
 			return { kind: "STRING_LITERAL", value: assignment.value } as SimpleTypeStringLiteral;
 		case HtmlNodeAttrAssignmentKind.BOOLEAN:
 			return { kind: "BOOLEAN_LITERAL", value: true } as SimpleTypeBooleanLiteral;
+		case HtmlNodeAttrAssignmentKind.ELEMENT:
+			return checker.getTypeAtLocation(assignment.expression);
 		case HtmlNodeAttrAssignmentKind.EXPRESSION:
 			return checker.getTypeAtLocation(assignment.expression);
 		case HtmlNodeAttrAssignmentKind.MIXED:

--- a/packages/lit-analyzer/src/lib/rules/util/type/extract-binding-types.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/type/extract-binding-types.ts
@@ -63,7 +63,7 @@ export function inferTypeFromAssignment(assignment: HtmlNodeAttrAssignment, chec
 			return { kind: "STRING_LITERAL", value: assignment.value } as SimpleTypeStringLiteral;
 		case HtmlNodeAttrAssignmentKind.BOOLEAN:
 			return { kind: "BOOLEAN_LITERAL", value: true } as SimpleTypeBooleanLiteral;
-		case HtmlNodeAttrAssignmentKind.ELEMENT:
+		case HtmlNodeAttrAssignmentKind.ELEMENT_EXPRESSION:
 			return checker.getTypeAtLocation(assignment.expression);
 		case HtmlNodeAttrAssignmentKind.EXPRESSION:
 			return checker.getTypeAtLocation(assignment.expression);

--- a/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-in-element-binding.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-in-element-binding.ts
@@ -1,0 +1,27 @@
+import { SimpleType, typeToString } from "ts-simple-type";
+import { HtmlNodeAttr } from "../../../analyze/types/html-node/html-node-attr-types.js";
+import { RuleModuleContext } from "../../../analyze/types/rule/rule-module-context.js";
+import { rangeFromHtmlNodeAttr } from "../../../analyze/util/range-util.js";
+import { isLitDirective } from "../directive/is-lit-directive.js";
+
+/**
+ * Checks that the type represents a directive, which is the only valid
+ * value for element expressions.
+ *
+ * Note: This currently checks against the lit-html 1.x interface for a
+ * directive. When lit-analyzer can detect Lit 2 directives it will check that
+ * the directive is specifically a Lit 2 directive.
+ */
+export function isAssignableInElementBinding(htmlAttr: HtmlNodeAttr, type: SimpleType, context: RuleModuleContext): boolean | undefined {
+	// TODO (justinfagnani): is there a better way to determine if the
+	// type *contains* any, rather than *is* any?
+	if (!isLitDirective(type) && !(type.kind === "ANY")) {
+		context.report({
+			location: rangeFromHtmlNodeAttr(htmlAttr),
+			message: `Type '${typeToString(type)}' is not a directive'`
+		});
+		return false;
+	}
+
+	return true;
+}

--- a/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-in-element-binding.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-in-element-binding.ts
@@ -15,7 +15,7 @@ import { isLitDirective } from "../directive/is-lit-directive.js";
 export function isAssignableInElementBinding(htmlAttr: HtmlNodeAttr, type: SimpleType, context: RuleModuleContext): boolean | undefined {
 	// TODO (justinfagnani): is there a better way to determine if the
 	// type *contains* any, rather than *is* any?
-	if (!isLitDirective(type) && !(type.kind === "ANY")) {
+	if (!isLitDirective(type) && type.kind !== "ANY") {
 		context.report({
 			location: rangeFromHtmlNodeAttr(htmlAttr),
 			message: `Type '${typeToString(type)}' is not a directive'`

--- a/packages/lit-analyzer/src/test/parser/html-document/parse-bindings.ts
+++ b/packages/lit-analyzer/src/test/parser/html-document/parse-bindings.ts
@@ -17,6 +17,20 @@ tsTest("Correctly parses binding without a missing start quote", t => {
 	t.is((assignment as IHtmlNodeAttrAssignmentMixed).values[1], '"');
 });
 
+tsTest("Parses element binding", t => {
+	const res = parseHtml("<input ${ref(testRef)} />");
+	const attr = res.findAttr(attr => attr.name.startsWith("_"))!;
+	t.is(attr.assignment!.kind, HtmlNodeAttrAssignmentKind.ELEMENT);
+});
+
+tsTest("Parses multiple element bindings", t => {
+	const res = parseHtml("<input ${x} ${y}/>");
+	const input = res.rootNodes[0];
+	// Make sure we have two attributes even though the expression
+	// length is the same
+	t.is(input.attributes.length, 2);
+});
+
 tsTest("Correctly parses binding with no quotes", t => {
 	const res = parseHtml('<input value=${"text"} />');
 	const attr = res.findAttr(attr => attr.name === "value")!;

--- a/packages/lit-analyzer/src/test/parser/html-document/parse-bindings.ts
+++ b/packages/lit-analyzer/src/test/parser/html-document/parse-bindings.ts
@@ -31,6 +31,13 @@ tsTest("Parses multiple element bindings", t => {
 	t.is(input.attributes.length, 2);
 });
 
+tsTest("Parses more than 10 element bindings", t => {
+	const res = parseHtml("<input ${a} ${b} ${c} ${d} ${e} ${f} ${g} ${h} ${i} ${j} ${k}/>");
+	const input = res.rootNodes[0];
+	t.is(input.attributes.length, 11);
+	t.is(input.attributes[10].assignment!.kind, HtmlNodeAttrAssignmentKind.ELEMENT_EXPRESSION);
+});
+
 tsTest("Correctly parses binding with no quotes", t => {
 	const res = parseHtml('<input value=${"text"} />');
 	const attr = res.findAttr(attr => attr.name === "value")!;

--- a/packages/lit-analyzer/src/test/parser/html-document/parse-bindings.ts
+++ b/packages/lit-analyzer/src/test/parser/html-document/parse-bindings.ts
@@ -20,7 +20,7 @@ tsTest("Correctly parses binding without a missing start quote", t => {
 tsTest("Parses element binding", t => {
 	const res = parseHtml("<input ${ref(testRef)} />");
 	const attr = res.findAttr(attr => attr.name.startsWith("_"))!;
-	t.is(attr.assignment!.kind, HtmlNodeAttrAssignmentKind.ELEMENT);
+	t.is(attr.assignment!.kind, HtmlNodeAttrAssignmentKind.ELEMENT_EXPRESSION);
 });
 
 tsTest("Parses multiple element bindings", t => {

--- a/packages/lit-analyzer/src/test/rules/no-complex-attribute-binding.ts
+++ b/packages/lit-analyzer/src/test/rules/no-complex-attribute-binding.ts
@@ -32,3 +32,8 @@ tsTest("Don't check for the assignability of complex types in attribute bindings
 	);
 	hasNoDiagnostics(t, diagnostics);
 });
+
+tsTest("Ignore element expressions", t => {
+	const { diagnostics } = getDiagnostics("html`<input ${{x: 1}} />`", { rules: { "no-incompatible-type-binding": false } });
+	hasNoDiagnostics(t, diagnostics);
+});

--- a/packages/lit-analyzer/src/test/rules/no-incompatible-type-binding.ts
+++ b/packages/lit-analyzer/src/test/rules/no-incompatible-type-binding.ts
@@ -3,6 +3,43 @@ import { hasDiagnostic, hasNoDiagnostics } from "../helpers/assert.js";
 import { makeElement } from "../helpers/generate-test-file.js";
 import { tsTest } from "../helpers/ts-test.js";
 
+tsTest("Element binding: non-directive not allowed", t => {
+	const { diagnostics } = getDiagnostics("html`<input ${123} />`");
+	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
+});
+
+tsTest("Element binding: directive allowed", t => {
+	const { diagnostics } = getDiagnostics(`
+export interface Part { }
+
+const ifDefined: (value: unknown) => (part: Part) => void;
+
+html\`<input \${ifDefined(10)} />\`
+	`);
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("Element binding: custom directive allowed", t => {
+	const { diagnostics } = getDiagnostics(`
+export interface Part { }
+
+const ifDefined: (value: unknown) => (part: Part) => void;
+const ifExists = (value: any) => ifDefined(value === null ? undefined : value);
+
+html\`<input \${ifExists(10)} />\`
+	`);
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("Element binding: any allowed", t => {
+	const { diagnostics } = getDiagnostics(`
+const ifDefined: any;
+
+html\`<input \${ifDefined(10)} />\`
+	`);
+	hasNoDiagnostics(t, diagnostics);
+});
+
 tsTest("Attribute binding: 'no-incompatible-type-binding' is not emitted when the rule is turned off", t => {
 	const { diagnostics } = getDiagnostics('html`<input maxlength="foo" />`', { rules: { "no-incompatible-type-binding": "off" } });
 	hasNoDiagnostics(t, diagnostics);

--- a/packages/lit-analyzer/src/test/rules/no-unknown-attribute.ts
+++ b/packages/lit-analyzer/src/test/rules/no-unknown-attribute.ts
@@ -28,3 +28,8 @@ tsTest("Don't report unknown data- attributes", t => {
 	const { diagnostics } = getDiagnostics("html`<input data-foo='' />`", { rules: { "no-unknown-attribute": true } });
 	hasNoDiagnostics(t, diagnostics);
 });
+
+tsTest("Don't report element expressions", t => {
+	const { diagnostics } = getDiagnostics("html`<input ${x} />`", { rules: { "no-unknown-attribute": true } });
+	hasNoDiagnostics(t, diagnostics);
+});


### PR DESCRIPTION
This adds support for expressions in "element position":

```ts
html`<input ${ref(inputRef)}>`
```

These expressions are written in attribute name position, so a number of assumptions in the code base change. We need to generate unique substitutions so that multiple element expressions per element are supported. We also need to use the attribute name location object in several places because the attribute assignment location object doesn't exist. And we need a new assignment type to differentiate between element expressions and unbound boolean attributes.

This PR doesn't not update `isLitDirective()` to detect Lit 2 directive results. That's a follow-on task and when that's done this should be updated to _only_ only Lit 2 directives and not lit-html 1.x directives.

cc @43081j and @aomarks I can't add you as reviewers, but your feedback would be very appreciated!