### PR TITLE
Recognize Lit 2 directives

### DIFF
--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -46,7 +46,7 @@
 		"didyoumean2": "4.1.0",
 		"fast-glob": "^2.2.6",
 		"parse5": "5.1.0",
-		"ts-simple-type": "2.0.0-next.0",
+		"ts-simple-type": "~1.0.5",
 		"vscode-css-languageservice": "4.3.0",
 		"vscode-html-languageservice": "3.1.0",
 		"web-component-analyzer": "~1.1.1"

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -46,7 +46,7 @@
 		"didyoumean2": "4.1.0",
 		"fast-glob": "^2.2.6",
 		"parse5": "5.1.0",
-		"ts-simple-type": "~1.0.5",
+		"ts-simple-type": "2.0.0-next.0",
 		"vscode-css-languageservice": "4.3.0",
 		"vscode-html-languageservice": "3.1.0",
 		"web-component-analyzer": "~1.1.1"

--- a/packages/lit-analyzer/src/lib/rules/util/directive/is-lit-directive.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/directive/is-lit-directive.ts
@@ -10,11 +10,16 @@ const partTypeNames: ReadonlySet<string | undefined> = new Set([
 ]);
 
 /**
- * Checks whether a type is a lit directive.
- * It will return true if the type is a function that takes a Part type and returns a void.
- * @param type
+ * Checks whether a type is a lit-html 1.x or Lit 2 directive.
  */
 export function isLitDirective(type: SimpleType): boolean {
+	return isLit1Directive(type) || isLit2Directive(type);
+}
+
+/**
+ * Checks whether a type is a lit-html 1.x directive.
+ */
+export function isLit1Directive(type: SimpleType): boolean {
 	switch (type.kind) {
 		case "ALIAS":
 			return type.name === "DirectiveFn" || isLitDirective(type.target);
@@ -45,4 +50,11 @@ export function isLitDirective(type: SimpleType): boolean {
 		default:
 			return false;
 	}
+}
+
+/**
+ * Checks whether a type is a Lit 2 directive.
+ */
+export function isLit2Directive(type: SimpleType): boolean {
+	return type.kind === "INTERFACE" && type.name === "DirectiveResult";
 }

--- a/packages/lit-analyzer/src/lib/rules/util/directive/is-lit-directive.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/directive/is-lit-directive.ts
@@ -22,9 +22,9 @@ export function isLitDirective(type: SimpleType): boolean {
 export function isLit1Directive(type: SimpleType): boolean {
 	switch (type.kind) {
 		case "ALIAS":
-			return type.name === "DirectiveFn" || isLitDirective(type.target);
+			return type.name === "DirectiveFn" || isLit1Directive(type.target);
 		case "OBJECT":
-			return type.call != null && isLitDirective(type.call);
+			return type.call != null && isLit1Directive(type.call);
 		case "FUNCTION": {
 			// We expect a directive to be a function with at least one argument that
 			// returns void.
@@ -46,7 +46,7 @@ export function isLit1Directive(type: SimpleType): boolean {
 		}
 		case "GENERIC_ARGUMENTS":
 			// Test for the built in type from lit-html: Directive<NodePart>
-			return (type.target.kind === "FUNCTION" && type.target.name === "Directive") || isLitDirective(type.target);
+			return (type.target.kind === "FUNCTION" && type.target.name === "Directive") || isLit1Directive(type.target);
 		default:
 			return false;
 	}

--- a/packages/lit-analyzer/src/lib/rules/util/directive/is-lit-directive.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/directive/is-lit-directive.ts
@@ -56,5 +56,14 @@ export function isLit1Directive(type: SimpleType): boolean {
  * Checks whether a type is a Lit 2 directive.
  */
 export function isLit2Directive(type: SimpleType): boolean {
-	return type.kind === "INTERFACE" && type.name === "DirectiveResult";
+	switch (type.kind) {
+		case "INTERFACE": {
+			return type.name === "DirectiveResult";
+		}
+		case "GENERIC_ARGUMENTS": {
+			return isLit2Directive(type.target);
+		}
+		default:
+			return false;
+	}
 }

--- a/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-in-element-binding.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-in-element-binding.ts
@@ -2,7 +2,7 @@ import { SimpleType, typeToString } from "ts-simple-type";
 import { HtmlNodeAttr } from "../../../analyze/types/html-node/html-node-attr-types.js";
 import { RuleModuleContext } from "../../../analyze/types/rule/rule-module-context.js";
 import { rangeFromHtmlNodeAttr } from "../../../analyze/util/range-util.js";
-import { isLitDirective } from "../directive/is-lit-directive.js";
+import { isLit2Directive, isLit1Directive } from "../directive/is-lit-directive.js";
 
 /**
  * Checks that the type represents a directive, which is the only valid
@@ -15,11 +15,18 @@ import { isLitDirective } from "../directive/is-lit-directive.js";
 export function isAssignableInElementBinding(htmlAttr: HtmlNodeAttr, type: SimpleType, context: RuleModuleContext): boolean | undefined {
 	// TODO (justinfagnani): is there a better way to determine if the
 	// type *contains* any, rather than *is* any?
-	if (!isLitDirective(type) && type.kind !== "ANY") {
-		context.report({
-			location: rangeFromHtmlNodeAttr(htmlAttr),
-			message: `Type '${typeToString(type)}' is not a directive'`
-		});
+	if (!isLit2Directive(type) && type.kind !== "ANY") {
+		if (isLit1Directive(type)) {
+			context.report({
+				location: rangeFromHtmlNodeAttr(htmlAttr),
+				message: `Type '${typeToString(type)}' is a lit-html 1.0 directive, not a Lit 2 directive'`
+			});
+		} else {
+			context.report({
+				location: rangeFromHtmlNodeAttr(htmlAttr),
+				message: `Type '${typeToString(type)}' is not a Lit 2 directive'`
+			});
+		}
 		return false;
 	}
 

--- a/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-in-element-binding.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-in-element-binding.ts
@@ -5,12 +5,8 @@ import { rangeFromHtmlNodeAttr } from "../../../analyze/util/range-util.js";
 import { isLit2Directive, isLit1Directive } from "../directive/is-lit-directive.js";
 
 /**
- * Checks that the type represents a directive, which is the only valid
+ * Checks that the type represents a Lit 2 directive, which is the only valid
  * value for element expressions.
- *
- * Note: This currently checks against the lit-html 1.x interface for a
- * directive. When lit-analyzer can detect Lit 2 directives it will check that
- * the directive is specifically a Lit 2 directive.
  */
 export function isAssignableInElementBinding(htmlAttr: HtmlNodeAttr, type: SimpleType, context: RuleModuleContext): boolean | undefined {
 	// TODO (justinfagnani): is there a better way to determine if the


### PR DESCRIPTION
This adds `isLit1Directive()` and `isLit2Directive()` and makes `isLitDirective()` return true if either does. Most call sites are left alone so they detect either Lit 1 or Lit 2 directives. The `isAssignableInElementBinding()` helper checks for a Lit 2 directive specifically.