### PR TITLE
Add type-parameters to html template literals

### DIFF
--- a/packages/vscode-lit-plugin/syntaxes/vscode-lit-html/lit-html.json
+++ b/packages/vscode-lit-plugin/syntaxes/vscode-lit-html/lit-html.json
@@ -15,12 +15,19 @@
 		{
 			"name": "string.js.taggedTemplate",
 			"contentName": "meta.embedded.block.html",
-			"begin": "(?x)(\\b(?:\\w+\\.)*(?:html|raw)\\s*)(`)",
+			"begin": "(?x)(\\b(?:\\w+\\.)*(?:html|raw)\\s*)(<.+>)?(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.js"
 				},
 				"2": {
+					"patterns": [
+						{
+							"include": "source.ts#type-parameters"
+						}
+					]
+				},
+				"3": {
 					"name": "punctuation.definition.string.template.begin.js"
 				}
 			},


### PR DESCRIPTION
Add type parameters to html template literals:

```ts
html<DataSource>`
<div>
    Content
</div>
`
```

