### PR TITLE
Fix the lit-analyzer CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
+## [2.0.0-pre.2]
+
+### Fixed
+
+- Fixed import issue in lit-analyzer CLI.
+
 ## [2.0.0-pre.1]
 
 ### Breaking

--- a/packages/lit-analyzer/cli.js
+++ b/packages/lit-analyzer/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-require("./lib/index.cjs")
+require("./index.js")
 	.cli()
 	// eslint-disable-next-line no-console
 	.catch(console.log);

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lit-analyzer",
-	"version": "2.0.0-pre.1",
+	"version": "2.0.0-pre.2",
 	"description": "CLI that type checks bindings in lit-html templates",
 	"author": "runem",
 	"license": "MIT",

--- a/packages/lit-analyzer/src/lib/analyze/constants.ts
+++ b/packages/lit-analyzer/src/lib/analyze/constants.ts
@@ -16,6 +16,6 @@ export const DIAGNOSTIC_SOURCE = "lit-plugin";
 
 export const TS_IGNORE_FLAG = "@ts-ignore";
 
-export const VERSION = "2.0.0-pre.1";
+export const VERSION = "2.0.0-pre.2";
 
 export const MAX_RUNNING_TIME_PER_OPERATION = 150; // Default to small timeouts. Opt in to larger timeouts where necessary.


### PR DESCRIPTION
Looks like we updated some paths. Manually confirmed that the CLI works after this change.

Fixes https://github.com/runem/lit-analyzer/issues/258