### PR TITLE
Allow the `any` type to bind to security sensitive properties

### DIFF
--- a/packages/lit-analyzer/package-lock.json
+++ b/packages/lit-analyzer/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lit-analyzer",
-	"version": "2.0.0-pre.1",
+	"version": "2.0.0-pre.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lit-analyzer",
-			"version": "2.0.0-pre.1",
+			"version": "2.0.0-pre.2",
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^2.4.2",

--- a/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-binding-under-security-system.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-binding-under-security-system.ts
@@ -66,6 +66,10 @@ function checkClosureSecurityAssignability(typeB: SimpleType, htmlAttr: HtmlNode
 	if (overriddenTypes === undefined) {
 		return undefined;
 	}
+	// `any` is allowed to bind to anything.
+	if (typeB.kind === "ANY") {
+		return undefined;
+	}
 	// Directives are responsible for their own security.
 	if (isLitDirective(typeB)) {
 		return undefined;

--- a/packages/lit-analyzer/src/test/rules/security-system.ts
+++ b/packages/lit-analyzer/src/test/rules/security-system.ts
@@ -84,44 +84,54 @@ tsTest(testName, t => {
 
 testName = "May pass either a SafeUrl, a TrustedResourceUrl, a string, or `any` to img src with ClosureSafeTypes config";
 tsTest(testName, t => {
-	const { diagnostics } = getDiagnostics(preface + "html`<img src=${safeUrl}>`", { securitySystem: "ClosureSafeTypes" });
-	hasNoDiagnostics(t, diagnostics);
+	hasNoDiagnostics(t, getDiagnostics(preface + "html`<img src=${safeUrl}>`", { securitySystem: "ClosureSafeTypes" }).diagnostics);
 
-	const { diagnostics: moreDiagnostics } = getDiagnostics(preface + "html`<img src=${trustedResourceUrl}>`", {
-		securitySystem: "ClosureSafeTypes"
-	});
-	hasNoDiagnostics(t, moreDiagnostics);
+	hasNoDiagnostics(
+		t,
+		getDiagnostics(preface + "html`<img src=${trustedResourceUrl}>`", {
+			securitySystem: "ClosureSafeTypes"
+		}).diagnostics
+	);
 
-	const { diagnostics: evenMoreDiagnostics } = getDiagnostics(preface + "html`<img src=${'/img.webp'}>`", {
-		securitySystem: "ClosureSafeTypes"
-	});
-	hasNoDiagnostics(t, evenMoreDiagnostics);
+	hasNoDiagnostics(
+		t,
+		getDiagnostics(preface + "html`<img src=${'/img.webp'}>`", {
+			securitySystem: "ClosureSafeTypes"
+		}).diagnostics
+	);
 
-	const { diagnostics: evenMoreDiagnostics } = getDiagnostics(preface + "html`<img src=${anyValue}>`", {
-		securitySystem: "ClosureSafeTypes"
-	});
-	hasNoDiagnostics(t, evenMoreDiagnostics);
+	hasNoDiagnostics(
+		t,
+		getDiagnostics(preface + "html`<img src=${anyValue}>`", {
+			securitySystem: "ClosureSafeTypes"
+		}).diagnostics
+	);
 });
 
 testName = "May pass either a SafeUrl, a TrustedResourceUrl, a string, or `any` to img .src with ClosureSafeTypes config";
 tsTest(testName, t => {
-	const { diagnostics } = getDiagnostics(preface + "html`<img .src=${safeUrl}>`", { securitySystem: "ClosureSafeTypes" });
-	hasNoDiagnostics(t, diagnostics);
+	hasNoDiagnostics(t, getDiagnostics(preface + "html`<img .src=${safeUrl}>`", { securitySystem: "ClosureSafeTypes" }).diagnostics);
 
-	const { diagnostics: moreDiagnostics } = getDiagnostics(preface + "html`<img .src=${trustedResourceUrl}>`", {
-		securitySystem: "ClosureSafeTypes"
-	});
-	hasNoDiagnostics(t, moreDiagnostics);
+	hasNoDiagnostics(
+		t,
+		getDiagnostics(preface + "html`<img .src=${trustedResourceUrl}>`", {
+			securitySystem: "ClosureSafeTypes"
+		}).diagnostics
+	);
 
-	const { diagnostics: evenMoreDiagnostics } = getDiagnostics(preface + "html`<img .src=${'/img.webp'}>`", {
-		securitySystem: "ClosureSafeTypes"
-	});
-	hasNoDiagnostics(t, evenMoreDiagnostics);
+	hasNoDiagnostics(
+		t,
+		getDiagnostics(preface + "html`<img .src=${'/img.webp'}>`", {
+			securitySystem: "ClosureSafeTypes"
+		}).diagnostics
+	);
 
-	const { diagnostics: evenMoreDiagnostics } = getDiagnostics(preface + "html`<img .src=${anyValue}>`", {
-		securitySystem: "ClosureSafeTypes"
-	});
-	hasNoDiagnostics(t, evenMoreDiagnostics);
+	hasNoDiagnostics(
+		t,
+		getDiagnostics(preface + "html`<img .src=${anyValue}>`", {
+			securitySystem: "ClosureSafeTypes"
+		}).diagnostics
+	);
 });
 
 testName = "May pass a string to style with ClosureSafeTypes config";

--- a/packages/lit-analyzer/src/test/rules/security-system.ts
+++ b/packages/lit-analyzer/src/test/rules/security-system.ts
@@ -39,7 +39,7 @@ tsTest(testName, t => {
 });
 
 testName = "May not pass a TrustedResourceUrl to script .src with default config";
-tsTest.only(testName, t => {
+tsTest(testName, t => {
 	const { diagnostics } = getDiagnostics(preface + "html`<script .src=${trustedResourceUrl}></script>`");
 	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
 });

--- a/packages/lit-analyzer/src/test/rules/security-system.ts
+++ b/packages/lit-analyzer/src/test/rules/security-system.ts
@@ -70,15 +70,15 @@ tsTest(testName, t => {
 
 testName = "May pass either a SafeUrl or a TrustedResourceUrl or a string to img src with ClosureSafeTypes config";
 tsTest(testName, t => {
-	const { diagnostics } = getDiagnostics(preface + "html`<img src=${safeUrl}></script>`", { securitySystem: "ClosureSafeTypes" });
+	const { diagnostics } = getDiagnostics(preface + "html`<img src=${safeUrl}>`", { securitySystem: "ClosureSafeTypes" });
 	hasNoDiagnostics(t, diagnostics);
 
-	const { diagnostics: moreDiagnostics } = getDiagnostics(preface + "html`<img src=${trustedResourceUrl}></script>`", {
+	const { diagnostics: moreDiagnostics } = getDiagnostics(preface + "html`<img src=${trustedResourceUrl}>`", {
 		securitySystem: "ClosureSafeTypes"
 	});
 	hasNoDiagnostics(t, moreDiagnostics);
 
-	const { diagnostics: evenMoreDiagnostics } = getDiagnostics(preface + "html`<img src=${'/img.webp'}></script>`", {
+	const { diagnostics: evenMoreDiagnostics } = getDiagnostics(preface + "html`<img src=${'/img.webp'}>`", {
 		securitySystem: "ClosureSafeTypes"
 	});
 	hasNoDiagnostics(t, evenMoreDiagnostics);
@@ -86,15 +86,15 @@ tsTest(testName, t => {
 
 testName = "May pass either a SafeUrl or a TrustedResourceUrl or a string to img .src with ClosureSafeTypes config";
 tsTest(testName, t => {
-	const { diagnostics } = getDiagnostics(preface + "html`<img .src=${safeUrl}></script>`", { securitySystem: "ClosureSafeTypes" });
+	const { diagnostics } = getDiagnostics(preface + "html`<img .src=${safeUrl}>`", { securitySystem: "ClosureSafeTypes" });
 	hasNoDiagnostics(t, diagnostics);
 
-	const { diagnostics: moreDiagnostics } = getDiagnostics(preface + "html`<img .src=${trustedResourceUrl}></script>`", {
+	const { diagnostics: moreDiagnostics } = getDiagnostics(preface + "html`<img .src=${trustedResourceUrl}>`", {
 		securitySystem: "ClosureSafeTypes"
 	});
 	hasNoDiagnostics(t, moreDiagnostics);
 
-	const { diagnostics: evenMoreDiagnostics } = getDiagnostics(preface + "html`<img .src=${'/img.webp'}></script>`", {
+	const { diagnostics: evenMoreDiagnostics } = getDiagnostics(preface + "html`<img .src=${'/img.webp'}>`", {
 		securitySystem: "ClosureSafeTypes"
 	});
 	hasNoDiagnostics(t, evenMoreDiagnostics);

--- a/packages/lit-analyzer/src/test/rules/security-system.ts
+++ b/packages/lit-analyzer/src/test/rules/security-system.ts
@@ -10,6 +10,8 @@ const preface = `
   const trustedResourceUrl = new TrustedResourceUrl();
   const safeUrl = new SafeUrl();
   const safeStyle = new SafeStyle();
+
+	const anyValue: any = {};
 `;
 
 tsTest("May bind string to script src with default config", t => {
@@ -68,7 +70,19 @@ tsTest(testName, t => {
 	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
 });
 
-testName = "May pass either a SafeUrl or a TrustedResourceUrl or a string to img src with ClosureSafeTypes config";
+testName = "May pass `any` to script src with ClosureSafeTypes config";
+tsTest(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<script src=${anyValue}></script>`", { securitySystem: "ClosureSafeTypes" });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+testName = "May pass `any` to script .src with ClosureSafeTypes config";
+tsTest(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<script .src=${anyValue}></script>`", { securitySystem: "ClosureSafeTypes" });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+testName = "May pass either a SafeUrl, a TrustedResourceUrl, a string, or `any` to img src with ClosureSafeTypes config";
 tsTest(testName, t => {
 	const { diagnostics } = getDiagnostics(preface + "html`<img src=${safeUrl}>`", { securitySystem: "ClosureSafeTypes" });
 	hasNoDiagnostics(t, diagnostics);
@@ -82,9 +96,14 @@ tsTest(testName, t => {
 		securitySystem: "ClosureSafeTypes"
 	});
 	hasNoDiagnostics(t, evenMoreDiagnostics);
+
+	const { diagnostics: evenMoreDiagnostics } = getDiagnostics(preface + "html`<img src=${anyValue}>`", {
+		securitySystem: "ClosureSafeTypes"
+	});
+	hasNoDiagnostics(t, evenMoreDiagnostics);
 });
 
-testName = "May pass either a SafeUrl or a TrustedResourceUrl or a string to img .src with ClosureSafeTypes config";
+testName = "May pass either a SafeUrl, a TrustedResourceUrl, a string, or `any` to img .src with ClosureSafeTypes config";
 tsTest(testName, t => {
 	const { diagnostics } = getDiagnostics(preface + "html`<img .src=${safeUrl}>`", { securitySystem: "ClosureSafeTypes" });
 	hasNoDiagnostics(t, diagnostics);
@@ -95,6 +114,11 @@ tsTest(testName, t => {
 	hasNoDiagnostics(t, moreDiagnostics);
 
 	const { diagnostics: evenMoreDiagnostics } = getDiagnostics(preface + "html`<img .src=${'/img.webp'}>`", {
+		securitySystem: "ClosureSafeTypes"
+	});
+	hasNoDiagnostics(t, evenMoreDiagnostics);
+
+	const { diagnostics: evenMoreDiagnostics } = getDiagnostics(preface + "html`<img .src=${anyValue}>`", {
 		securitySystem: "ClosureSafeTypes"
 	});
 	hasNoDiagnostics(t, evenMoreDiagnostics);
@@ -121,5 +145,17 @@ tsTest(testName, t => {
 testName = "May pass a SafeStyle to .style with ClosureSafeTypes config";
 tsTest(testName, t => {
 	const { diagnostics } = getDiagnostics(preface + "html`<div .style=${safeStyle}></div>`", { securitySystem: "ClosureSafeTypes" });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+testName = "May pass a `any` to style with ClosureSafeTypes config";
+tsTest(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<div style=${anyValue}></div>`", { securitySystem: "ClosureSafeTypes" });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+testName = "May pass a `any` to .style with ClosureSafeTypes config";
+tsTest(testName, t => {
+	const { diagnostics } = getDiagnostics(preface + "html`<div .style=${anyValue}></div>`", { securitySystem: "ClosureSafeTypes" });
 	hasNoDiagnostics(t, diagnostics);
 });

--- a/packages/vscode-lit-plugin/package-lock.json
+++ b/packages/vscode-lit-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lit-plugin",
-	"version": "1.2.1",
+	"version": "1.2.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lit-plugin",
-			"version": "1.2.1",
+			"version": "1.2.4",
 			"license": "MIT",
 			"dependencies": {
 				"typescript": "~4.6.3"
@@ -21,7 +21,7 @@
 				"wireit": "^0.1.1"
 			},
 			"engines": {
-				"vscode": "^1.30.0"
+				"vscode": "^1.63.0"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {


### PR DESCRIPTION
From the CL description:

> Note that this is not security sensitive code. The actual security boundary is at runtime. This is just the type checker assisting the developer, predicting what the runtime enforcement will allow/reject.
>
> Allowing `any` here aligns with TypeScript's general type checking principles, where you're allowed to do just about anything you want with an `any` typed value.

This upstreams <http://cl/354348347>.