### PR TITLE
Rename `LitDefinition`'s `target` to `targets` and remove the non-array case.

### DIFF
--- a/packages/lit-analyzer/src/lib/analyze/document-analyzer/css/lit-css-document-analyzer.ts
+++ b/packages/lit-analyzer/src/lib/analyze/document-analyzer/css/lit-css-document-analyzer.ts
@@ -67,7 +67,7 @@ export class LitCssDocumentAnalyzer {
 
 					return {
 						fromRange: documentRangeToSFRange(document, { start, end }),
-						target: nodes.map(node => ({
+						targets: nodes.map(node => ({
 							kind: "node",
 							node: getNodeIdentifier(node, context.ts) || node
 						}))
@@ -85,10 +85,12 @@ export class LitCssDocumentAnalyzer {
 
 				return {
 					fromRange: documentRangeToSFRange(document, { start, end }),
-					target: {
-						kind: "node",
-						node: getNodeIdentifier(node, context.ts) || node
-					}
+					targets: [
+						{
+							kind: "node",
+							node: getNodeIdentifier(node, context.ts) || node
+						}
+					]
 				};
 			}
 		}

--- a/packages/lit-analyzer/src/lib/analyze/document-analyzer/html/definition/definition-for-html-attr.ts
+++ b/packages/lit-analyzer/src/lib/analyze/document-analyzer/html/definition/definition-for-html-attr.ts
@@ -14,22 +14,26 @@ export function definitionForHtmlAttr(htmlAttr: HtmlNodeAttr, { htmlStore, ts }:
 
 		return {
 			fromRange: rangeFromHtmlNodeAttr(htmlAttr),
-			target: {
-				kind: "node",
-				node: getNodeIdentifier(node, ts) || node,
-				name: target.name
-			}
+			targets: [
+				{
+					kind: "node",
+					node: getNodeIdentifier(node, ts) || node,
+					name: target.name
+				}
+			]
 		};
 	} else if (isHtmlEvent(target) && target.declaration != null) {
 		const node = target.declaration.node;
 
 		return {
 			fromRange: rangeFromHtmlNodeAttr(htmlAttr),
-			target: {
-				kind: "node",
-				node: getNodeIdentifier(node, ts) || node,
-				name: target.name
-			}
+			targets: [
+				{
+					kind: "node",
+					node: getNodeIdentifier(node, ts) || node,
+					name: target.name
+				}
+			]
 		};
 	}
 	return;

--- a/packages/lit-analyzer/src/lib/analyze/document-analyzer/html/definition/definition-for-html-node.ts
+++ b/packages/lit-analyzer/src/lib/analyze/document-analyzer/html/definition/definition-for-html-node.ts
@@ -12,9 +12,11 @@ export function definitionForHtmlNode(htmlNode: HtmlNode, { htmlStore, ts }: Lit
 
 	return {
 		fromRange: rangeFromHtmlNode(htmlNode),
-		target: {
-			kind: "node",
-			node: getNodeIdentifier(node, ts) || node
-		}
+		targets: [
+			{
+				kind: "node",
+				node: getNodeIdentifier(node, ts) || node
+			}
+		]
 	};
 }

--- a/packages/lit-analyzer/src/lib/analyze/types/lit-definition.ts
+++ b/packages/lit-analyzer/src/lib/analyze/types/lit-definition.ts
@@ -24,5 +24,5 @@ export type LitDefinitionTarget = LitDefinitionTargetNode | LitDefinitionTargetR
 
 export interface LitDefinition {
 	fromRange: SourceFileRange;
-	target: LitDefinitionTarget[] | LitDefinitionTarget;
+	targets: LitDefinitionTarget[];
 }

--- a/packages/lit-analyzer/src/test/indexer/index-entries.ts
+++ b/packages/lit-analyzer/src/test/indexer/index-entries.ts
@@ -104,7 +104,7 @@ const assertIdentifiesClass = ({
 
 /**
  * Asserts that `entry` is a `HtmlNodeIndexEntry` that describes an element with
- * tag name `tagName` that is defined by a class named `className` in
+ * tag name `tagName` that is defined by a single class named `className` in
  * `sourceFile`.
  */
 const assertEntryTargetsClass = ({
@@ -128,12 +128,10 @@ const assertEntryTargetsClass = ({
 	t.is(entryNode.kind, HtmlNodeKind.NODE, "The entry should not originate from an `<svg>` or `<style>`.");
 	t.is(entryNode.tagName, tagName, `The origin element is not a \`<${tagName}>\`.`);
 
-	const { target } = entry.definition;
-	if (Array.isArray(target)) {
-		// TODO: What about single item arrays?
-		throw new Error("The definition should have a single target.");
-	}
+	const { targets } = entry.definition;
+	t.is(targets.length, 1, "The definition should have a single target.");
 
+	const [target] = targets;
 	if (target.kind !== "node") {
 		throw new Error("The definition target should be a `LitDefinitionTargetNode`.");
 	}
@@ -301,7 +299,7 @@ tsTest("Attribute references are not created for attributes that don't map to kn
 
 /**
  * Asserts that `entry` is a `HtmlNodeAttrIndexEntry` with name `name` and kind
- * `kind` that targets a `LitDefinitionTargetNode`.
+ * `kind` that has a single target `LitDefinitionTargetNode`.
  */
 const assertIsAttrRefAndGetTarget = ({
 	t,
@@ -322,12 +320,10 @@ const assertIsAttrRefAndGetTarget = ({
 	t.is(entryAttr.name, name, `The attribute name should be \`${name}\`.`);
 	t.is(entryAttr.kind, kind, `The attribute kind should be \`${kind}\`.`);
 
-	const { target } = entry.definition;
-	if (Array.isArray(target)) {
-		// TODO: What about single item arrays?
-		throw new Error("The definition should have a single target.");
-	}
+	const { targets } = entry.definition;
+	t.is(targets.length, 1, "The definition should have a single target.");
 
+	const [target] = targets;
 	if (target.kind !== "node") {
 		throw new Error("The definition target should be a `LitDefinitionTargetNode`.");
 	}

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-definition.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-definition.ts
@@ -5,7 +5,7 @@ import { translateRange } from "./translate-range.js";
 
 export function translateDefinition(definition: LitDefinition): DefinitionInfoAndBoundSpan {
 	return {
-		definitions: [...(Array.isArray(definition.target) ? definition.target : [definition.target])].map(translateDefinitionInfo),
+		definitions: definition.targets.map(translateDefinitionInfo),
 		textSpan: translateRange(definition.fromRange)
 	};
 }


### PR DESCRIPTION
This simplifies using `target` slightly by not requiring a test for the non-array case.