### PR TITLE
Fix matching of Clutz-generated types against allowed type names.

### DIFF
--- a/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-binding-under-security-system.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-binding-under-security-system.ts
@@ -112,7 +112,7 @@ function matchesAtLeastOneNominalType(typeNames: string[], typeB: SimpleType): b
 			return true;
 		}
 		const normalized = normalizeTypeName(typeBName);
-		if (normalized !== undefined && typeNames.includes(typeBName)) {
+		if (normalized !== undefined && typeNames.includes(normalized)) {
 			return true;
 		}
 	}

--- a/packages/lit-analyzer/src/test/rules/security-system.ts
+++ b/packages/lit-analyzer/src/test/rules/security-system.ts
@@ -169,3 +169,29 @@ tsTest(testName, t => {
 	const { diagnostics } = getDiagnostics(preface + "html`<div .style=${anyValue}></div>`", { securitySystem: "ClosureSafeTypes" });
 	hasNoDiagnostics(t, diagnostics);
 });
+
+testName = "Types renamed by Clutz are properly matched against allowed types.";
+tsTest(testName, t => {
+	const { diagnostics } = getDiagnostics(
+		[
+			{
+				fileName: "main.ts",
+				text: `
+					// A type name known to have been output by Clutz.
+					class module$contents$goog$html$SafeUrl_SafeUrl {}
+
+					html\`<a href='\${"abc" as module$contents$goog$html$SafeUrl_SafeUrl}'>This is a link.</a>\`;
+
+					// A type name of the same format.
+					class module$some$clutz$name_TrustedResourceUrl {}
+
+					html\`<script src='\${"abc" as module$some$clutz$name_TrustedResourceUrl}'></script>\`;
+				`
+			}
+		],
+		{
+			securitySystem: "ClosureSafeTypes"
+		}
+	);
+	hasNoDiagnostics(t, diagnostics);
+});


### PR DESCRIPTION
Currently, the original name of the Clutz-generated type is being matched against the names of the allowed types. This PR updates this to match against the normalized version.