### PR TITLE
The `ifDefined` directive should return a non-null type, not just non-`undefined`.

### DIFF
--- a/packages/lit-analyzer/src/test/rules/no-nullable-attribute-binding.ts
+++ b/packages/lit-analyzer/src/test/rules/no-nullable-attribute-binding.ts
@@ -25,3 +25,11 @@ tsTest("Can assign 'null' in property binding", t => {
 	const { diagnostics } = getDiagnostics('html`<input .selectionEnd="${{} as number | null}" />`');
 	hasNoDiagnostics(t, diagnostics);
 });
+
+tsTest("Return type of `ifDefined` is not `null`", t => {
+	const { diagnostics } = getDiagnostics(`
+		const ifDefined = <T>(x: T) => x ?? "non-null";
+		html\`<input some-attribute="$\{ifDefined(Math.random() < 0.5 ? 123 : null)}" />\`;
+	`);
+	hasNoDiagnostics(t, diagnostics);
+});


### PR DESCRIPTION
The return type of `ifDefined` is determined with a special rule here:

https://github.com/runem/lit-analyzer/blob/92c084da4d33d6fbdd8b29603d2003387e65dbb3/packages/lit-analyzer/src/lib/rules/util/directive/get-directive.ts#L45-L63

But the analyzer doesn't realize that the return type can't be `null` in Lit 2, because it only removes `undefined` ([matching Lit 1's behavior](https://github.com/lit/lit/blob/e66eb66d9244d019a5d5b17a692a6269b806b552/src/directives/if-defined.ts#L28)):

https://github.com/runem/lit-analyzer/blob/92c084da4d33d6fbdd8b29603d2003387e65dbb3/packages/lit-analyzer/src/lib/rules/util/directive/get-directive.ts#L52