### PR TITLE
Add support for TypeScript 5.0

### DIFF
--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -47,7 +47,7 @@
 		"ts-simple-type": "~1.0.5",
 		"vscode-css-languageservice": "4.3.0",
 		"vscode-html-languageservice": "3.1.0",
-		"web-component-analyzer": "~1.1.1"
+		"web-component-analyzer": "~1.1.7"
 	},
 	"devDependencies": {
 		"@appnest/readme": "^1.2.7",

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -54,6 +54,7 @@
 		"@rollup/plugin-json": "4.1.0",
 		"@rollup/plugin-node-resolve": "^8.1.0",
 		"@rollup/plugin-replace": "^2.3.3",
+		"@types/babel__traverse": "7.18.2",
 		"@types/node": "^14.0.13",
 		"@wessberg/rollup-plugin-ts": "^1.2.25",
 		"ava": "^3.8.2",

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -68,6 +68,7 @@
 		"typescript-3.7": "npm:typescript@~3.7.4",
 		"typescript-3.8": "npm:typescript@~3.8.3",
 		"typescript-3.9": "npm:typescript@~3.9.3",
+		"typescript-5.0": "npm:typescript@~5.0.3",
 		"vscode-web-custom-data": "0.3.0"
 	},
 	"ava": {

--- a/packages/lit-analyzer/test/helpers/ts-test.ts
+++ b/packages/lit-analyzer/test/helpers/ts-test.ts
@@ -5,11 +5,11 @@ import { setTypescriptModule } from "../../src/analyze/ts-module";
 
 type TestFunction = (title: string, implementation: Implementation) => void;
 
-type TsModuleKind = "current" | "3.6" | "3.7" | "3.8" | "3.9";
+type TsModuleKind = "current" | "3.6" | "3.7" | "3.8" | "3.9" | "5.0";
 
-const TS_MODULES_ALL: TsModuleKind[] = ["current", "3.6", "3.7", "3.8", "3.9"];
+const TS_MODULES_ALL: TsModuleKind[] = ["current", "3.6", "3.7", "3.8", "3.9", "5.0"];
 
-const TS_MODULES_DEFAULT: TsModuleKind[] = ["3.6", "3.7", "3.8", "3.9"];
+const TS_MODULES_DEFAULT: TsModuleKind[] = ["3.6", "3.7", "3.8", "3.9", "5.0"];
 
 /**
  * Returns the name of the module to require for a specific ts module kind
@@ -22,6 +22,7 @@ function getTsModuleNameWithKind(kind: TsModuleKind | undefined): string {
 		case "3.7":
 		case "3.8":
 		case "3.9":
+		case "5.0":
 			return `typescript-${kind}`;
 		case "current":
 		case undefined:

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -37,7 +37,7 @@
 		"lit-html": "https://github.com/mjbvz/vscode-lit-html.git#1.11.1",
 		"ts-lit-plugin": "1.2.1",
 		"vscode-styled-components": "https://github.com/styled-components/vscode-styled-components/archive/refs/tags/v1.7.8.tar.gz",
-		"web-component-analyzer": "~1.1.1"
+		"web-component-analyzer": "~1.1.7"
 	},
 	"devDependencies": {
 		"@types/node": "^14.0.13",

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -36,7 +36,7 @@
 	"dependencies": {
 		"lit-html": "https://github.com/mjbvz/vscode-lit-html.git#1.11.1",
 		"ts-lit-plugin": "1.2.1",
-		"vscode-styled-components": "https://github.com/styled-components/vscode-styled-components#4320c223666ea835e8c63c85573c2704f550b7df",
+		"vscode-styled-components": "https://github.com/styled-components/vscode-styled-components/archive/refs/tags/v1.7.8.tar.gz",
 		"web-component-analyzer": "~1.1.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
- Installs TypeScript 5.0 as a dev dependency and adds it to the list of versions that are tested.
- Updates web-component-analyzer to `1.1.7`, which added support for TypeScript 5.0.
- Fixes a few dependencies that no longer work and works around a TS compiler API deprecation.