### PR TITLE
Update web-component-analyzer dependency to fix ts5.x support

### DIFF
--- a/.github/workflows/test_vscode.yml
+++ b/.github/workflows/test_vscode.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
       - run: npm ci
       # Test normally on Mac
       - run: npm run test:packaged

--- a/.github/workflows/test_vscode.yml
+++ b/.github/workflows/test_vscode.yml
@@ -1,5 +1,9 @@
 name: VSCode Integration Test
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/test_vscode.yml
+++ b/.github/workflows/test_vscode.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 18.x
       - run: npm ci
       # Test normally on Mac
       - run: npm run test:packaged

--- a/.github/workflows/test_vscode.yml
+++ b/.github/workflows/test_vscode.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 16.x
       - run: npm ci
       # Test normally on Mac
       - run: npm run test:packaged

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        node: [16, 17]
+        node: [16, 17, 18, 20]
         exclude:
           - os: windows-latest
             node: "17"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,17 +15,17 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        node: [16, 17, 18, 20]
+        node: [18, 20]
         exclude:
           - os: windows-latest
             node: "17"
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,9 @@
 {
-	"typescript.tsdk": "node_modules/typescript/lib"
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"editor.wordWrapColumn": 100,
+	"editor.rulers": [
+		{
+			"column": 100
+		}
+	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"lint-staged": "^10.2.10",
 				"nodemon": "^2.0.4",
 				"prettier": "^2.4.1",
-				"typescript": "~4.4.3",
+				"typescript": "~4.4.4",
 				"wireit": "^0.9.5"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"nodemon": "^2.0.4",
 				"prettier": "^2.4.1",
 				"typescript": "~4.4.3",
-				"wireit": "^0.1.1"
+				"wireit": "^0.9.5"
 			}
 		},
 		"node_modules/@appnest/readme": {
@@ -5817,6 +5817,12 @@
 				"json5": "lib/cli.js"
 			}
 		},
+		"node_modules/jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+			"dev": true
+		},
 		"node_modules/jsonfile": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -8212,6 +8218,17 @@
 				"read": "1"
 			}
 		},
+		"node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
 		"node_modules/proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -10232,19 +10249,22 @@
 			}
 		},
 		"node_modules/wireit": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/wireit/-/wireit-0.1.1.tgz",
-			"integrity": "sha512-6Ocik3cdyFiA1yJY7y2f+WwKGb2o1exl/gbW4aThHuA8Im9WkeiU9oadpO6NFZDQn5R/67Q2H34a/IfEbvlrkQ==",
+			"version": "0.9.5",
+			"resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.5.tgz",
+			"integrity": "sha512-dKKNAwLxQjbPPMrltPxMUFKvLy2z6hlVjvR/qitvPm8GEQyb/1QYBG7ObvOQLsi95uAXpkWLJXBYkCKeVcMVgA==",
 			"dev": true,
 			"dependencies": {
+				"braces": "^3.0.2",
 				"chokidar": "^3.5.3",
-				"fast-glob": "^3.2.11"
+				"fast-glob": "^3.2.11",
+				"jsonc-parser": "^3.0.0",
+				"proper-lockfile": "^4.1.2"
 			},
 			"bin": {
 				"wireit": "bin/wireit.js"
 			},
 			"engines": {
-				"node": ">=16.7.0"
+				"node": ">=14.14.0"
 			}
 		},
 		"node_modules/word-wrap": {
@@ -15037,6 +15057,12 @@
 				"minimist": "^1.2.0"
 			}
 		},
+		"jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+			"dev": true
+		},
 		"jsonfile": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -16884,6 +16910,17 @@
 				"read": "1"
 			}
 		},
+		"proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -18449,13 +18486,16 @@
 			}
 		},
 		"wireit": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/wireit/-/wireit-0.1.1.tgz",
-			"integrity": "sha512-6Ocik3cdyFiA1yJY7y2f+WwKGb2o1exl/gbW4aThHuA8Im9WkeiU9oadpO6NFZDQn5R/67Q2H34a/IfEbvlrkQ==",
+			"version": "0.9.5",
+			"resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.5.tgz",
+			"integrity": "sha512-dKKNAwLxQjbPPMrltPxMUFKvLy2z6hlVjvR/qitvPm8GEQyb/1QYBG7ObvOQLsi95uAXpkWLJXBYkCKeVcMVgA==",
 			"dev": true,
 			"requires": {
+				"braces": "^3.0.2",
 				"chokidar": "^3.5.3",
-				"fast-glob": "^3.2.11"
+				"fast-glob": "^3.2.11",
+				"jsonc-parser": "^3.0.0",
+				"proper-lockfile": "^4.1.2"
 			}
 		},
 		"word-wrap": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
 		"nodemon": "^2.0.4",
 		"prettier": "^2.4.1",
 		"typescript": "~4.4.3",
-		"wireit": "^0.1.1"
+		"wireit": "^0.9.5"
 	},
 	"husky": {
 		"hooks": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 		"lint-staged": "^10.2.10",
 		"nodemon": "^2.0.4",
 		"prettier": "^2.4.1",
-		"typescript": "~4.4.3",
+		"typescript": "~4.4.4",
 		"wireit": "^0.9.5"
 	},
 	"husky": {

--- a/packages/lit-analyzer/package-lock.json
+++ b/packages/lit-analyzer/package-lock.json
@@ -17,7 +17,7 @@
 				"ts-simple-type": "~2.0.0-next.0",
 				"vscode-css-languageservice": "4.3.0",
 				"vscode-html-languageservice": "3.1.0",
-				"web-component-analyzer": "^1.1.7"
+				"web-component-analyzer": "^2.0.0-next.5"
 			},
 			"bin": {
 				"lit-analyzer": "cli.js"
@@ -28,7 +28,7 @@
 				"ava": "^3.8.2",
 				"rimraf": "^3.0.2",
 				"tslib": "^2.0.0",
-				"typescript": "~3.9.10",
+				"typescript": "~4.4.4",
 				"typescript-4.8": "npm:typescript@~4.8.2",
 				"typescript-5.0": "npm:typescript@~5.0.4",
 				"wireit": "^0.9.5"
@@ -139,6 +139,19 @@
 			"resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-0.3.7.tgz",
 			"integrity": "sha512-bDXWURwpDpe1mA5E9eldmI0Mpt9zGprhtN/ZTLOJjsAMyeMy1UT7WvGRQghYewIYBYxDZurChhe4DrsPbcCVrA==",
 			"dev": true
+		},
+		"node_modules/@appnest/readme/node_modules/typescript": {
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
 		},
 		"node_modules/@appnest/readme/node_modules/web-component-analyzer": {
 			"version": "1.0.3",
@@ -3614,9 +3627,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "3.9.10",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -3864,13 +3877,13 @@
 			}
 		},
 		"node_modules/web-component-analyzer": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-1.1.7.tgz",
-			"integrity": "sha512-SqCqN4nU9fU+j0CKXJQ8E4cslLsaezhagY6xoi+hoNPPd55GzR6MY1r5jkoJUVu+g4Wy4uB+JglTt7au4vQ1uA==",
+			"version": "2.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.5.tgz",
+			"integrity": "sha512-QaQwuwFaBuwc7RwX0KdR9bc57s9Jqj+PcekIt3c7WXRY4vGOr/rjyG8YWuT2R7KmGBh+KrCdY/KynMlWRCVR3w==",
 			"dependencies": {
 				"fast-glob": "^3.2.2",
-				"ts-simple-type": "~1.0.5",
-				"typescript": "^3.8.3",
+				"ts-simple-type": "2.0.0-next.0",
+				"typescript": "~4.4.3",
 				"yargs": "^15.3.1"
 			},
 			"bin": {
@@ -3951,11 +3964,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/web-component-analyzer/node_modules/ts-simple-type": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-1.0.7.tgz",
-			"integrity": "sha512-zKmsCQs4dZaeSKjEA7pLFDv7FHHqAFLPd0Mr//OIJvu8M+4p4bgSFJwZSEBEg3ec9W7RzRz1vi8giiX0+mheBQ=="
 		},
 		"node_modules/web-component-analyzer/node_modules/wrap-ansi": {
 			"version": "6.2.0",
@@ -4230,6 +4238,12 @@
 					"version": "0.3.7",
 					"resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-0.3.7.tgz",
 					"integrity": "sha512-bDXWURwpDpe1mA5E9eldmI0Mpt9zGprhtN/ZTLOJjsAMyeMy1UT7WvGRQghYewIYBYxDZurChhe4DrsPbcCVrA==",
+					"dev": true
+				},
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
 					"dev": true
 				},
 				"web-component-analyzer": {
@@ -6812,9 +6826,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.10",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
 		},
 		"typescript-4.8": {
 			"version": "npm:typescript@4.8.4",
@@ -7004,13 +7018,13 @@
 			}
 		},
 		"web-component-analyzer": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-1.1.7.tgz",
-			"integrity": "sha512-SqCqN4nU9fU+j0CKXJQ8E4cslLsaezhagY6xoi+hoNPPd55GzR6MY1r5jkoJUVu+g4Wy4uB+JglTt7au4vQ1uA==",
+			"version": "2.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.5.tgz",
+			"integrity": "sha512-QaQwuwFaBuwc7RwX0KdR9bc57s9Jqj+PcekIt3c7WXRY4vGOr/rjyG8YWuT2R7KmGBh+KrCdY/KynMlWRCVR3w==",
 			"requires": {
 				"fast-glob": "^3.2.2",
-				"ts-simple-type": "~1.0.5",
-				"typescript": "^3.8.3",
+				"ts-simple-type": "2.0.0-next.0",
+				"typescript": "~4.4.3",
 				"yargs": "^15.3.1"
 			},
 			"dependencies": {
@@ -7066,11 +7080,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-				},
-				"ts-simple-type": {
-					"version": "1.0.7",
-					"resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-1.0.7.tgz",
-					"integrity": "sha512-zKmsCQs4dZaeSKjEA7pLFDv7FHHqAFLPd0Mr//OIJvu8M+4p4bgSFJwZSEBEg3ec9W7RzRz1vi8giiX0+mheBQ=="
 				},
 				"wrap-ansi": {
 					"version": "6.2.0",

--- a/packages/lit-analyzer/package-lock.json
+++ b/packages/lit-analyzer/package-lock.json
@@ -31,7 +31,7 @@
 				"typescript": "~3.9.10",
 				"typescript-4.8": "npm:typescript@~4.8.2",
 				"typescript-5.0": "npm:typescript@~5.0.4",
-				"wireit": "^0.1.1"
+				"wireit": "^0.9.5"
 			}
 		},
 		"node_modules/@appnest/readme": {
@@ -2092,6 +2092,12 @@
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
 		},
+		"node_modules/jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+			"dev": true
+		},
 		"node_modules/jsonfile": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -2934,6 +2940,17 @@
 				"node": ">= 0.6.0"
 			}
 		},
+		"node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
 		"node_modules/pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -3164,6 +3181,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/reusify": {
@@ -4009,19 +4035,22 @@
 			}
 		},
 		"node_modules/wireit": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/wireit/-/wireit-0.1.1.tgz",
-			"integrity": "sha512-6Ocik3cdyFiA1yJY7y2f+WwKGb2o1exl/gbW4aThHuA8Im9WkeiU9oadpO6NFZDQn5R/67Q2H34a/IfEbvlrkQ==",
+			"version": "0.9.5",
+			"resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.5.tgz",
+			"integrity": "sha512-dKKNAwLxQjbPPMrltPxMUFKvLy2z6hlVjvR/qitvPm8GEQyb/1QYBG7ObvOQLsi95uAXpkWLJXBYkCKeVcMVgA==",
 			"dev": true,
 			"dependencies": {
+				"braces": "^3.0.2",
 				"chokidar": "^3.5.3",
-				"fast-glob": "^3.2.11"
+				"fast-glob": "^3.2.11",
+				"jsonc-parser": "^3.0.0",
+				"proper-lockfile": "^4.1.2"
 			},
 			"bin": {
 				"wireit": "bin/wireit.js"
 			},
 			"engines": {
-				"node": ">=16.7.0"
+				"node": ">=14.14.0"
 			}
 		},
 		"node_modules/wrap-ansi": {
@@ -5658,6 +5687,12 @@
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
 		},
+		"jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+			"dev": true
+		},
 		"jsonfile": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -6274,6 +6309,17 @@
 			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
 			"dev": true
 		},
+		"proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
 		"pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -6447,6 +6493,12 @@
 				"onetime": "^5.1.0",
 				"signal-exit": "^3.0.2"
 			}
+		},
+		"retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"dev": true
 		},
 		"reusify": {
 			"version": "1.0.4",
@@ -7085,13 +7137,16 @@
 			}
 		},
 		"wireit": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/wireit/-/wireit-0.1.1.tgz",
-			"integrity": "sha512-6Ocik3cdyFiA1yJY7y2f+WwKGb2o1exl/gbW4aThHuA8Im9WkeiU9oadpO6NFZDQn5R/67Q2H34a/IfEbvlrkQ==",
+			"version": "0.9.5",
+			"resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.5.tgz",
+			"integrity": "sha512-dKKNAwLxQjbPPMrltPxMUFKvLy2z6hlVjvR/qitvPm8GEQyb/1QYBG7ObvOQLsi95uAXpkWLJXBYkCKeVcMVgA==",
 			"dev": true,
 			"requires": {
+				"braces": "^3.0.2",
 				"chokidar": "^3.5.3",
-				"fast-glob": "^3.2.11"
+				"fast-glob": "^3.2.11",
+				"jsonc-parser": "^3.0.0",
+				"proper-lockfile": "^4.1.2"
 			}
 		},
 		"wrap-ansi": {

--- a/packages/lit-analyzer/package-lock.json
+++ b/packages/lit-analyzer/package-lock.json
@@ -17,7 +17,7 @@
 				"ts-simple-type": "~2.0.0-next.0",
 				"vscode-css-languageservice": "4.3.0",
 				"vscode-html-languageservice": "3.1.0",
-				"web-component-analyzer": "2.0.0-next.4"
+				"web-component-analyzer": "^1.1.7"
 			},
 			"bin": {
 				"lit-analyzer": "cli.js"
@@ -28,11 +28,9 @@
 				"ava": "^3.8.2",
 				"rimraf": "^3.0.2",
 				"tslib": "^2.0.0",
-				"typescript": "~4.4.3",
-				"typescript-3.6": "npm:typescript@~3.6.4",
-				"typescript-3.7": "npm:typescript@~3.7.4",
-				"typescript-3.8": "npm:typescript@~3.8.3",
-				"typescript-3.9": "npm:typescript@~3.9.3",
+				"typescript": "~3.9.10",
+				"typescript-4.8": "npm:typescript@~4.8.2",
+				"typescript-5.0": "npm:typescript@~5.0.4",
 				"wireit": "^0.1.1"
 			}
 		},
@@ -141,19 +139,6 @@
 			"resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-0.3.7.tgz",
 			"integrity": "sha512-bDXWURwpDpe1mA5E9eldmI0Mpt9zGprhtN/ZTLOJjsAMyeMy1UT7WvGRQghYewIYBYxDZurChhe4DrsPbcCVrA==",
 			"dev": true
-		},
-		"node_modules/@appnest/readme/node_modules/typescript": {
-			"version": "3.9.10",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
 		},
 		"node_modules/@appnest/readme/node_modules/web-component-analyzer": {
 			"version": "1.0.3",
@@ -3603,64 +3588,22 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
-		"node_modules/typescript-3.6": {
-			"name": "typescript",
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.5.tgz",
-			"integrity": "sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
-		"node_modules/typescript-3.7": {
-			"name": "typescript",
-			"version": "3.7.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.7.tgz",
-			"integrity": "sha512-MmQdgo/XenfZPvVLtKZOq9jQQvzaUAUpcKW8Z43x9B2fOm4S5g//tPtMweZUIP+SoBqrVPEIm+dJeQ9dfO0QdA==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
-		"node_modules/typescript-3.8": {
-			"name": "typescript",
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
-		"node_modules/typescript-3.9": {
-			"name": "typescript",
 			"version": "3.9.10",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
 			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/typescript-4.8": {
+			"name": "typescript",
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -3668,6 +3611,20 @@
 			},
 			"engines": {
 				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/typescript-5.0": {
+			"name": "typescript",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=12.20"
 			}
 		},
 		"node_modules/unique-string": {
@@ -3881,13 +3838,13 @@
 			}
 		},
 		"node_modules/web-component-analyzer": {
-			"version": "2.0.0-next.4",
-			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.4.tgz",
-			"integrity": "sha512-XZ4JOibgp+3OKAQ6K9v4gJOoHAurfXztbfX6FwqXIh4cNLTwHz4QcLDOFav+2ddKGpshM4MQrJaPCPXZeCv5+A==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-1.1.7.tgz",
+			"integrity": "sha512-SqCqN4nU9fU+j0CKXJQ8E4cslLsaezhagY6xoi+hoNPPd55GzR6MY1r5jkoJUVu+g4Wy4uB+JglTt7au4vQ1uA==",
 			"dependencies": {
 				"fast-glob": "^3.2.2",
-				"ts-simple-type": "2.0.0-next.0",
-				"typescript": "~4.4.3",
+				"ts-simple-type": "~1.0.5",
+				"typescript": "^3.8.3",
 				"yargs": "^15.3.1"
 			},
 			"bin": {
@@ -3968,6 +3925,11 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/web-component-analyzer/node_modules/ts-simple-type": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-1.0.7.tgz",
+			"integrity": "sha512-zKmsCQs4dZaeSKjEA7pLFDv7FHHqAFLPd0Mr//OIJvu8M+4p4bgSFJwZSEBEg3ec9W7RzRz1vi8giiX0+mheBQ=="
 		},
 		"node_modules/web-component-analyzer/node_modules/wrap-ansi": {
 			"version": "6.2.0",
@@ -4239,12 +4201,6 @@
 					"version": "0.3.7",
 					"resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-0.3.7.tgz",
 					"integrity": "sha512-bDXWURwpDpe1mA5E9eldmI0Mpt9zGprhtN/ZTLOJjsAMyeMy1UT7WvGRQghYewIYBYxDZurChhe4DrsPbcCVrA==",
-					"dev": true
-				},
-				"typescript": {
-					"version": "3.9.10",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
 					"dev": true
 				},
 				"web-component-analyzer": {
@@ -6804,32 +6760,20 @@
 			}
 		},
 		"typescript": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
-		},
-		"typescript-3.6": {
-			"version": "npm:typescript@3.6.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.5.tgz",
-			"integrity": "sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==",
-			"dev": true
-		},
-		"typescript-3.7": {
-			"version": "npm:typescript@3.7.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.7.tgz",
-			"integrity": "sha512-MmQdgo/XenfZPvVLtKZOq9jQQvzaUAUpcKW8Z43x9B2fOm4S5g//tPtMweZUIP+SoBqrVPEIm+dJeQ9dfO0QdA==",
-			"dev": true
-		},
-		"typescript-3.8": {
-			"version": "npm:typescript@3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
-			"dev": true
-		},
-		"typescript-3.9": {
-			"version": "npm:typescript@3.9.10",
+			"version": "3.9.10",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
+		},
+		"typescript-4.8": {
+			"version": "npm:typescript@4.8.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+			"dev": true
+		},
+		"typescript-5.0": {
+			"version": "npm:typescript@5.0.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
 			"dev": true
 		},
 		"unique-string": {
@@ -7008,13 +6952,13 @@
 			}
 		},
 		"web-component-analyzer": {
-			"version": "2.0.0-next.4",
-			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.4.tgz",
-			"integrity": "sha512-XZ4JOibgp+3OKAQ6K9v4gJOoHAurfXztbfX6FwqXIh4cNLTwHz4QcLDOFav+2ddKGpshM4MQrJaPCPXZeCv5+A==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-1.1.7.tgz",
+			"integrity": "sha512-SqCqN4nU9fU+j0CKXJQ8E4cslLsaezhagY6xoi+hoNPPd55GzR6MY1r5jkoJUVu+g4Wy4uB+JglTt7au4vQ1uA==",
 			"requires": {
 				"fast-glob": "^3.2.2",
-				"ts-simple-type": "2.0.0-next.0",
-				"typescript": "~4.4.3",
+				"ts-simple-type": "~1.0.5",
+				"typescript": "^3.8.3",
 				"yargs": "^15.3.1"
 			},
 			"dependencies": {
@@ -7070,6 +7014,11 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+				},
+				"ts-simple-type": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-1.0.7.tgz",
+					"integrity": "sha512-zKmsCQs4dZaeSKjEA7pLFDv7FHHqAFLPd0Mr//OIJvu8M+4p4bgSFJwZSEBEg3ec9W7RzRz1vi8giiX0+mheBQ=="
 				},
 				"wrap-ansi": {
 					"version": "6.2.0",

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -94,7 +94,7 @@
 		"vscode-css-languageservice": "4.3.0",
 		"vscode-html-languageservice": "3.1.0",
 		"@vscode/web-custom-data": "^0.4.2",
-		"web-component-analyzer": "^1.1.7"
+		"web-component-analyzer": "^2.0.0-next.5"
 	},
 	"devDependencies": {
 		"@appnest/readme": "^1.2.7",
@@ -102,7 +102,7 @@
 		"ava": "^3.8.2",
 		"rimraf": "^3.0.2",
 		"tslib": "^2.0.0",
-		"typescript": "~3.9.10",
+		"typescript": "~4.4.4",
 		"typescript-4.8": "npm:typescript@~4.8.2",
 		"typescript-5.0": "npm:typescript@~5.0.4",
 		"wireit": "^0.9.5"

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -64,7 +64,9 @@
 			],
 			"command": "ava --color",
 			"output": [],
-			"files": []
+			"files": [
+				"package.json"
+			]
 		},
 		"check-version": {
 			"dependencies": [

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -38,7 +38,8 @@
 			"command": "tsc --build --pretty",
 			"files": [
 				"src/**/*",
-				"tsconfig.json"
+				"tsconfig.json",
+				"../../tsconfig.json"
 			],
 			"output": [
 				"lib",
@@ -91,7 +92,7 @@
 		"vscode-css-languageservice": "4.3.0",
 		"vscode-html-languageservice": "3.1.0",
 		"@vscode/web-custom-data": "^0.4.2",
-		"web-component-analyzer": "2.0.0-next.4"
+		"web-component-analyzer": "^1.1.7"
 	},
 	"devDependencies": {
 		"@appnest/readme": "^1.2.7",
@@ -99,11 +100,9 @@
 		"ava": "^3.8.2",
 		"rimraf": "^3.0.2",
 		"tslib": "^2.0.0",
-		"typescript": "~4.4.3",
-		"typescript-3.6": "npm:typescript@~3.6.4",
-		"typescript-3.7": "npm:typescript@~3.7.4",
-		"typescript-3.8": "npm:typescript@~3.8.3",
-		"typescript-3.9": "npm:typescript@~3.9.3",
+		"typescript": "~3.9.10",
+		"typescript-4.8": "npm:typescript@~4.8.2",
+		"typescript-5.0": "npm:typescript@~5.0.4",
 		"wireit": "^0.1.1"
 	},
 	"ava": {

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -103,7 +103,7 @@
 		"typescript": "~3.9.10",
 		"typescript-4.8": "npm:typescript@~4.8.2",
 		"typescript-5.0": "npm:typescript@~5.0.4",
-		"wireit": "^0.1.1"
+		"wireit": "^0.9.5"
 	},
 	"ava": {
 		"cache": true,

--- a/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -1,10 +1,11 @@
 import * as tsModule from "typescript";
+import tsServerModule from "typescript/lib/tsserverlibrary.js";
 import { Node, Program, SourceFile } from "typescript";
 
 interface IVisitDependenciesContext {
 	program: Program;
 	ts: typeof tsModule;
-	project: ts.server.Project | undefined;
+	project: tsServerModule.server.Project | undefined;
 	directImportCache: WeakMap<SourceFile, Set<SourceFile>>;
 	emitIndirectImport(file: SourceFile, importedFrom?: SourceFile): boolean;
 	emitDirectImport?(file: SourceFile): void;
@@ -133,8 +134,8 @@ function visitDirectImports(node: Node, context: IVisitDependenciesContext): voi
 	node.forEachChild(child => visitDirectImports(child, context));
 }
 
-interface MaybeModernProgram extends ts.Program {
-	getModuleResolutionCache?(): ts.ModuleResolutionCache | undefined;
+interface MaybeModernProgram extends tsModule.Program {
+	getModuleResolutionCache?(): tsModule.ModuleResolutionCache | undefined;
 }
 
 /**
@@ -147,7 +148,7 @@ function emitDirectModuleImportWithName(moduleSpecifier: string, node: Node, con
 	const fromSourceFile = node.getSourceFile();
 
 	// Resolve the imported string
-	let result: ts.ResolvedModuleWithFailedLookupLocations | undefined;
+	let result: tsModule.ResolvedModuleWithFailedLookupLocations | undefined;
 
 	if (context.project) {
 		result = context.project.getResolvedModuleWithFailedLookupLocationsFromCache(moduleSpecifier, fromSourceFile.fileName);

--- a/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -143,12 +143,14 @@ function emitDirectModuleImportWithName(moduleSpecifier: string, node: Node, con
 	const fromSourceFile = node.getSourceFile();
 
 	// Resolve the imported string
-	const result = context.project
-		? context.project.getResolvedModuleWithFailedLookupLocationsFromCache(moduleSpecifier, fromSourceFile.fileName)
-		: "getResolvedModuleWithFailedLookupLocationsFromCache" in context.program
-		? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-		  (context.program as any)["getResolvedModuleWithFailedLookupLocationsFromCache"](moduleSpecifier, fromSourceFile.fileName)
-		: undefined;
+	let result: ts.ResolvedModuleWithFailedLookupLocations | undefined;
+
+	if (context.project) {
+		result = context.project.getResolvedModuleWithFailedLookupLocationsFromCache(moduleSpecifier, fromSourceFile.fileName);
+	} else if ("getResolvedModuleWithFailedLookupLocationsFromCache" in context.program) {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		result = (context.program as any)["getResolvedModuleWithFailedLookupLocationsFromCache"](moduleSpecifier, fromSourceFile.fileName);
+	}
 
 	if (result?.resolvedModule?.resolvedFileName != null) {
 		const resolvedModule = result.resolvedModule;

--- a/packages/lit-analyzer/src/test/helpers/ts-test.ts
+++ b/packages/lit-analyzer/src/test/helpers/ts-test.ts
@@ -5,11 +5,11 @@ import { setTypescriptModule } from "../../lib/analyze/ts-module.js";
 
 type TestFunction = (title: string, implementation: Implementation) => void;
 
-type TsModuleKind = "current" | "3.6" | "3.7" | "3.8" | "3.9";
+const TS_MODULES_ALL = ["current", "4.8", "5.0"] as const;
 
-const TS_MODULES_ALL: TsModuleKind[] = ["current", "3.6", "3.7", "3.8", "3.9"];
+type TsModuleKind = typeof TS_MODULES_ALL[number];
 
-const TS_MODULES_DEFAULT: TsModuleKind[] = ["3.6", "3.7", "3.8", "3.9"];
+const TS_MODULES_DEFAULT: TsModuleKind[] = ["current", "4.8", "5.0"];
 
 /**
  * Returns the name of the module to require for a specific ts module kind
@@ -18,10 +18,8 @@ const TS_MODULES_DEFAULT: TsModuleKind[] = ["3.6", "3.7", "3.8", "3.9"];
 function getTsModuleNameWithKind(kind: TsModuleKind | undefined): string {
 	// Return the corresponding ts module
 	switch (kind) {
-		case "3.6":
-		case "3.7":
-		case "3.8":
-		case "3.9":
+		case "4.8":
+		case "5.0":
 			return `typescript-${kind}`;
 		case "current":
 		case undefined:

--- a/packages/ts-lit-plugin/package-lock.json
+++ b/packages/ts-lit-plugin/package-lock.json
@@ -9,13 +9,13 @@
 			"version": "1.2.1",
 			"license": "MIT",
 			"dependencies": {
-				"web-component-analyzer": "2.0.0-next.4"
+				"web-component-analyzer": "^2.0.0-next.5"
 			},
 			"devDependencies": {
 				"@types/node": "^14.0.13",
 				"esbuild": "^0.14.34",
 				"rimraf": "^3.0.2",
-				"typescript": "~4.4.3",
+				"typescript": "~4.4.4",
 				"wireit": "^0.1.1"
 			}
 		},
@@ -971,9 +971,9 @@
 			}
 		},
 		"node_modules/web-component-analyzer": {
-			"version": "2.0.0-next.4",
-			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.4.tgz",
-			"integrity": "sha512-XZ4JOibgp+3OKAQ6K9v4gJOoHAurfXztbfX6FwqXIh4cNLTwHz4QcLDOFav+2ddKGpshM4MQrJaPCPXZeCv5+A==",
+			"version": "2.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.5.tgz",
+			"integrity": "sha512-QaQwuwFaBuwc7RwX0KdR9bc57s9Jqj+PcekIt3c7WXRY4vGOr/rjyG8YWuT2R7KmGBh+KrCdY/KynMlWRCVR3w==",
 			"dependencies": {
 				"fast-glob": "^3.2.2",
 				"ts-simple-type": "2.0.0-next.0",
@@ -1680,9 +1680,9 @@
 			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
 		},
 		"web-component-analyzer": {
-			"version": "2.0.0-next.4",
-			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.4.tgz",
-			"integrity": "sha512-XZ4JOibgp+3OKAQ6K9v4gJOoHAurfXztbfX6FwqXIh4cNLTwHz4QcLDOFav+2ddKGpshM4MQrJaPCPXZeCv5+A==",
+			"version": "2.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.5.tgz",
+			"integrity": "sha512-QaQwuwFaBuwc7RwX0KdR9bc57s9Jqj+PcekIt3c7WXRY4vGOr/rjyG8YWuT2R7KmGBh+KrCdY/KynMlWRCVR3w==",
 			"requires": {
 				"fast-glob": "^3.2.2",
 				"ts-simple-type": "2.0.0-next.0",

--- a/packages/ts-lit-plugin/package.json
+++ b/packages/ts-lit-plugin/package.json
@@ -58,13 +58,13 @@
 	],
 	"dependencies": {
 		"lit-analyzer": "^2.0.0-pre.1",
-		"web-component-analyzer": "2.0.0-next.4"
+		"web-component-analyzer": "^2.0.0-next.5"
 	},
 	"devDependencies": {
 		"@types/node": "^14.0.13",
 		"esbuild": "^0.14.34",
 		"rimraf": "^3.0.2",
-		"typescript": "~4.4.3",
+		"typescript": "~4.4.4",
 		"wireit": "^0.1.1"
 	},
 	"contributors": [

--- a/packages/vscode-lit-plugin/package-lock.json
+++ b/packages/vscode-lit-plugin/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.2.4",
 			"license": "MIT",
 			"dependencies": {
-				"typescript": "~4.6.3"
+				"typescript": "~4.4.4"
 			},
 			"devDependencies": {
 				"@types/mocha": "^9.1.0",
@@ -1979,8 +1979,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.6.3",
-			"license": "Apache-2.0",
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -3576,7 +3577,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.6.3"
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
 		},
 		"uc.micro": {
 			"version": "1.0.6",

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -164,7 +164,7 @@
 		}
 	},
 	"dependencies": {
-		"typescript": "~4.6.3"
+		"typescript": "~4.4.4"
 	},
 	"devDependencies": {
 		"@types/mocha": "^9.1.0",


### PR DESCRIPTION
* Update WCA
* Update typescript to match WCA's version

this should fix the various problems people are having

cc @rictic 

FYI i couldn't write an extra test that fails before this change as i'd need to change the repo's typescript to 5.x, and that breaks the build thanks to a mismatch of types

we could just publish a prerelease and test it manually

let me know what you think