### PR TITLE
Test to not report missing element type definitions when tag names which are static class properties

### DIFF
--- a/packages/lit-analyzer/src/test/rules/no-missing-element-type-definition.ts
+++ b/packages/lit-analyzer/src/test/rules/no-missing-element-type-definition.ts
@@ -16,7 +16,7 @@ tsTest("'no-missing-element-type-definition' reports diagnostic when element is 
 	hasDiagnostic(t, diagnostics, "no-missing-element-type-definition");
 });
 
-tsTest("'no-missing-element-type-definition' reports no diagnostic when element is not in HTMLElementTagNameMap", t => {
+tsTest("'no-missing-element-type-definition' reports no diagnostic when element is in HTMLElementTagNameMap", t => {
 	const { diagnostics } = getDiagnostics(
 		`
 		class MyElement extends HTMLElement { }; 
@@ -24,6 +24,27 @@ tsTest("'no-missing-element-type-definition' reports no diagnostic when element 
 		declare global {
 			interface HTMLElementTagNameMap {
 				"my-element": MyElement
+			}
+		}
+	`,
+		{
+			rules: { "no-missing-element-type-definition": true }
+		}
+	);
+
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("'no-missing-element-type-definition' reports no diagnostic when element is in HTMLElementTagNameMap using class property", t => {
+	const { diagnostics } = getDiagnostics(
+		`
+		class MyElement extends HTMLElement { 
+			static readonly TAG_NAME = "my-element"
+		}; 
+		customElements.define(MyElement.TAG_NAME, MyElement)
+		declare global {
+			interface HTMLElementTagNameMap {
+				[MyElement.TAG_NAME]: MyElement
 			}
 		}
 	`,


### PR DESCRIPTION
Test which proves _no-missing-element-type-definition_ is not reported when the tag name is a static class property.

Requires runem/web-component-analyzer#279