### PR TITLE
Fixes #313 by correctly using projects moduleResolution strategy if configured

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"lint-staged": "^10.2.10",
 				"nodemon": "^2.0.4",
 				"prettier": "^2.4.1",
-				"typescript": "~4.4.4",
+				"typescript": "~4.8.4",
 				"wireit": "^0.9.5"
 			}
 		},
@@ -9686,9 +9686,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -18024,9 +18024,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 		"lint-staged": "^10.2.10",
 		"nodemon": "^2.0.4",
 		"prettier": "^2.4.1",
-		"typescript": "~4.4.4",
+		"typescript": "~4.8.4",
 		"wireit": "^0.9.5"
 	},
 	"husky": {

--- a/packages/lit-analyzer/package-lock.json
+++ b/packages/lit-analyzer/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lit-analyzer",
-	"version": "2.0.0-pre.3",
+	"version": "2.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lit-analyzer",
-			"version": "2.0.0-pre.3",
+			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"@vscode/web-custom-data": "^0.4.2",

--- a/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -158,8 +158,8 @@ function emitDirectModuleImportWithName(moduleSpecifier: string, node: Node, con
 		result = (context.program as any)["getResolvedModuleWithFailedLookupLocationsFromCache"](moduleSpecifier, fromSourceFile.fileName);
 	} else {
 		const cache = (context.program as MaybeModernProgram).getModuleResolutionCache?.();
-		let mode: tsModule.ModuleKind.CommonJS | tsModule.ModuleKind.ESNext | undefined = undefined; // tsModule.ModuleKind.ESNext;
-		if ((context.ts.isImportDeclaration(node) && !node.importClause?.isTypeOnly) || (context.ts.isExportDeclaration(node) && !node.isTypeOnly)) {
+		let mode: tsModule.ModuleKind.CommonJS | tsModule.ModuleKind.ESNext | undefined = undefined;
+		if (context.ts.isImportDeclaration(node) || context.ts.isExportDeclaration(node)) {
 			if (node.moduleSpecifier != null && context.ts.isStringLiteral(node.moduleSpecifier) && context.ts.isSourceFile(node.parent)) {
 				mode = tsModule.getModeForUsageLocation(fromSourceFile, node.moduleSpecifier);
 			}

--- a/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -158,8 +158,15 @@ function emitDirectModuleImportWithName(moduleSpecifier: string, node: Node, con
 		result = (context.program as any)["getResolvedModuleWithFailedLookupLocationsFromCache"](moduleSpecifier, fromSourceFile.fileName);
 	} else {
 		const cache = (context.program as MaybeModernProgram).getModuleResolutionCache?.();
+		let mode: tsModule.ModuleKind.CommonJS | tsModule.ModuleKind.ESNext | undefined = undefined; // tsModule.ModuleKind.ESNext;
+		if ((context.ts.isImportDeclaration(node) && !node.importClause?.isTypeOnly) || (context.ts.isExportDeclaration(node) && !node.isTypeOnly)) {
+			if (node.moduleSpecifier != null && context.ts.isStringLiteral(node.moduleSpecifier) && context.ts.isSourceFile(node.parent)) {
+				mode = tsModule.getModeForUsageLocation(fromSourceFile, node.moduleSpecifier);
+			}
+		}
+
 		if (cache != null) {
-			result = context.ts.resolveModuleNameFromCache(moduleSpecifier, node.getSourceFile().fileName, cache);
+			result = context.ts.resolveModuleNameFromCache(moduleSpecifier, node.getSourceFile().fileName, cache, mode);
 		}
 	}
 

--- a/packages/ts-lit-plugin/package-lock.json
+++ b/packages/ts-lit-plugin/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"lit-analyzer": "^2.0.1",
 				"web-component-analyzer": "^2.0.0"
 			},
 			"devDependencies": {
@@ -18,17 +17,6 @@
 				"rimraf": "^3.0.2",
 				"typescript": "~5.2.2",
 				"wireit": "^0.1.1"
-			}
-		},
-		"node_modules/@babel/runtime": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-			"integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -69,28 +57,12 @@
 			"integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
 			"dev": true
 		},
-		"node_modules/@vscode/web-custom-data": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/@vscode/web-custom-data/-/web-custom-data-0.4.8.tgz",
-			"integrity": "sha512-rRiEeEX49wipCeGZo65mQJUEuCY3IXd6bet90eY6cMMQ9jBe2g3Njw/2ctbaxuACPnEKXTdW0dB7umxDln3Rzg=="
-		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/anymatch": {
@@ -142,19 +114,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/chokidar": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -195,37 +154,11 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
-		},
-		"node_modules/didyoumean2": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/didyoumean2/-/didyoumean2-4.1.0.tgz",
-			"integrity": "sha512-qTBmfQoXvhKO75D/05C8m+fteQmn4U46FWYiLhXtZQInzitXLWY0EQ/2oKnpAz9g2lQWW8jYcLcT+hPJGT+kig==",
-			"dependencies": {
-				"@babel/runtime": "^7.10.2",
-				"leven": "^3.1.0",
-				"lodash.deburr": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=10.13"
-			}
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -595,14 +528,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
 		"node_modules/fast-glob": {
 			"version": "3.2.11",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
@@ -696,14 +621,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -767,38 +684,6 @@
 				"node": ">=0.12.0"
 			}
 		},
-		"node_modules/leven": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/lit-analyzer": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/lit-analyzer/-/lit-analyzer-2.0.1.tgz",
-			"integrity": "sha512-4bHJLCbxywMHd9bnVkLDkCSHXs/KrlwUks75EhYtJNdzH07O5BSVdZdadbw4T2AvuYxb0xRO4ZjqgQJCkp8Kjg==",
-			"dependencies": {
-				"@vscode/web-custom-data": "^0.4.2",
-				"chalk": "^2.4.2",
-				"didyoumean2": "4.1.0",
-				"fast-glob": "^3.2.11",
-				"parse5": "5.1.0",
-				"ts-simple-type": "~2.0.0-next.0",
-				"vscode-css-languageservice": "4.3.0",
-				"vscode-html-languageservice": "3.1.0",
-				"web-component-analyzer": "^2.0.0"
-			},
-			"bin": {
-				"lit-analyzer": "cli.js"
-			}
-		},
-		"node_modules/lodash.deburr": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
-			"integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ=="
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -848,11 +733,6 @@
 			"dependencies": {
 				"wrappy": "1"
 			}
-		},
-		"node_modules/parse5": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
 		},
 		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
@@ -904,11 +784,6 @@
 			"engines": {
 				"node": ">=8.10.0"
 			}
-		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-			"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -988,17 +863,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1026,48 +890,6 @@
 			"engines": {
 				"node": ">=14.17"
 			}
-		},
-		"node_modules/vscode-css-languageservice": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-4.3.0.tgz",
-			"integrity": "sha512-BkQAMz4oVHjr0oOAz5PdeE72txlLQK7NIwzmclfr+b6fj6I8POwB+VoXvrZLTbWt9hWRgfvgiQRkh5JwrjPJ5A==",
-			"dependencies": {
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^4.1.2",
-				"vscode-uri": "^2.1.2"
-			}
-		},
-		"node_modules/vscode-html-languageservice": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-3.1.0.tgz",
-			"integrity": "sha512-QAyRHI98bbEIBCqTzZVA0VblGU40na0txggongw5ZgTj9UVsVk5XbLT16O9OTcbqBGSqn0oWmFDNjK/XGIDcqg==",
-			"dependencies": {
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^4.1.2",
-				"vscode-uri": "^2.1.2"
-			}
-		},
-		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
-			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
-		},
-		"node_modules/vscode-languageserver-types": {
-			"version": "3.16.0-next.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
-			"integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q=="
-		},
-		"node_modules/vscode-nls": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
-			"integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
-		},
-		"node_modules/vscode-uri": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
-			"integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
 		},
 		"node_modules/web-component-analyzer": {
 			"version": "2.0.0",
@@ -1187,14 +1009,6 @@
 		}
 	},
 	"dependencies": {
-		"@babel/runtime": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-			"integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
-			"requires": {
-				"regenerator-runtime": "^0.14.0"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1224,23 +1038,10 @@
 			"integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
 			"dev": true
 		},
-		"@vscode/web-custom-data": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/@vscode/web-custom-data/-/web-custom-data-0.4.8.tgz",
-			"integrity": "sha512-rRiEeEX49wipCeGZo65mQJUEuCY3IXd6bet90eY6cMMQ9jBe2g3Njw/2ctbaxuACPnEKXTdW0dB7umxDln3Rzg=="
-		},
 		"ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-		},
-		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"requires": {
-				"color-convert": "^1.9.0"
-			}
 		},
 		"anymatch": {
 			"version": "3.1.2",
@@ -1282,16 +1083,6 @@
 				"fill-range": "^7.0.1"
 			}
 		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			}
-		},
 		"chokidar": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -1318,34 +1109,11 @@
 				"wrap-ansi": "^7.0.0"
 			}
 		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
-		},
-		"didyoumean2": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/didyoumean2/-/didyoumean2-4.1.0.tgz",
-			"integrity": "sha512-qTBmfQoXvhKO75D/05C8m+fteQmn4U46FWYiLhXtZQInzitXLWY0EQ/2oKnpAz9g2lQWW8jYcLcT+hPJGT+kig==",
-			"requires": {
-				"@babel/runtime": "^7.10.2",
-				"leven": "^3.1.0",
-				"lodash.deburr": "^4.1.0"
-			}
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -1525,11 +1293,6 @@
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
 		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
-		},
 		"fast-glob": {
 			"version": "3.2.11",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
@@ -1598,11 +1361,6 @@
 				"is-glob": "^4.0.1"
 			}
 		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
-		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1651,32 +1409,6 @@
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 		},
-		"leven": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
-		},
-		"lit-analyzer": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/lit-analyzer/-/lit-analyzer-2.0.1.tgz",
-			"integrity": "sha512-4bHJLCbxywMHd9bnVkLDkCSHXs/KrlwUks75EhYtJNdzH07O5BSVdZdadbw4T2AvuYxb0xRO4ZjqgQJCkp8Kjg==",
-			"requires": {
-				"@vscode/web-custom-data": "^0.4.2",
-				"chalk": "^2.4.2",
-				"didyoumean2": "4.1.0",
-				"fast-glob": "^3.2.11",
-				"parse5": "5.1.0",
-				"ts-simple-type": "~2.0.0-next.0",
-				"vscode-css-languageservice": "4.3.0",
-				"vscode-html-languageservice": "3.1.0",
-				"web-component-analyzer": "^2.0.0"
-			}
-		},
-		"lodash.deburr": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
-			"integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ=="
-		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1715,11 +1447,6 @@
 				"wrappy": "1"
 			}
 		},
-		"parse5": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
-		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1744,11 +1471,6 @@
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
-		},
-		"regenerator-runtime": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-			"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -1795,14 +1517,6 @@
 				"ansi-regex": "^5.0.1"
 			}
 		},
-		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
-		},
 		"to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1820,48 +1534,6 @@
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
 			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
-		},
-		"vscode-css-languageservice": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-4.3.0.tgz",
-			"integrity": "sha512-BkQAMz4oVHjr0oOAz5PdeE72txlLQK7NIwzmclfr+b6fj6I8POwB+VoXvrZLTbWt9hWRgfvgiQRkh5JwrjPJ5A==",
-			"requires": {
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^4.1.2",
-				"vscode-uri": "^2.1.2"
-			}
-		},
-		"vscode-html-languageservice": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-3.1.0.tgz",
-			"integrity": "sha512-QAyRHI98bbEIBCqTzZVA0VblGU40na0txggongw5ZgTj9UVsVk5XbLT16O9OTcbqBGSqn0oWmFDNjK/XGIDcqg==",
-			"requires": {
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^4.1.2",
-				"vscode-uri": "^2.1.2"
-			}
-		},
-		"vscode-languageserver-textdocument": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
-			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
-		},
-		"vscode-languageserver-types": {
-			"version": "3.16.0-next.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
-			"integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q=="
-		},
-		"vscode-nls": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
-			"integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
-		},
-		"vscode-uri": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
-			"integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
 		},
 		"web-component-analyzer": {
 			"version": "2.0.0",

--- a/packages/vscode-lit-plugin/package-lock.json
+++ b/packages/vscode-lit-plugin/package-lock.json
@@ -16,25 +16,12 @@
 				"@types/node": "^14.0.13",
 				"@types/vscode": "^1.30.0",
 				"esbuild": "^0.14.36",
-				"lit-analyzer": "^2.0.1",
 				"mocha": "^9.1.4",
 				"vsce": "^2.7.0",
 				"wireit": "^0.1.1"
 			},
 			"engines": {
 				"vscode": "^1.63.0"
-			}
-		},
-		"node_modules/@babel/runtime": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-			"integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -89,12 +76,6 @@
 			"version": "1.1.2",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/@vscode/web-custom-data": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/@vscode/web-custom-data/-/web-custom-data-0.4.8.tgz",
-			"integrity": "sha512-rRiEeEX49wipCeGZo65mQJUEuCY3IXd6bet90eY6cMMQ9jBe2g3Njw/2ctbaxuACPnEKXTdW0dB7umxDln3Rzg==",
-			"dev": true
 		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.1",
@@ -590,20 +571,6 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/didyoumean2": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/didyoumean2/-/didyoumean2-4.1.0.tgz",
-			"integrity": "sha512-qTBmfQoXvhKO75D/05C8m+fteQmn4U46FWYiLhXtZQInzitXLWY0EQ/2oKnpAz9g2lQWW8jYcLcT+hPJGT+kig==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.10.2",
-				"leven": "^3.1.0",
-				"lodash.deburr": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=10.13"
 			}
 		},
 		"node_modules/diff": {
@@ -1170,97 +1137,6 @@
 				"uc.micro": "^1.0.1"
 			}
 		},
-		"node_modules/lit-analyzer": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/lit-analyzer/-/lit-analyzer-2.0.1.tgz",
-			"integrity": "sha512-4bHJLCbxywMHd9bnVkLDkCSHXs/KrlwUks75EhYtJNdzH07O5BSVdZdadbw4T2AvuYxb0xRO4ZjqgQJCkp8Kjg==",
-			"dev": true,
-			"dependencies": {
-				"@vscode/web-custom-data": "^0.4.2",
-				"chalk": "^2.4.2",
-				"didyoumean2": "4.1.0",
-				"fast-glob": "^3.2.11",
-				"parse5": "5.1.0",
-				"ts-simple-type": "~2.0.0-next.0",
-				"vscode-css-languageservice": "4.3.0",
-				"vscode-html-languageservice": "3.1.0",
-				"web-component-analyzer": "^2.0.0"
-			},
-			"bin": {
-				"lit-analyzer": "cli.js"
-			}
-		},
-		"node_modules/lit-analyzer/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/lit-analyzer/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/lit-analyzer/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/lit-analyzer/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
-		"node_modules/lit-analyzer/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/lit-analyzer/node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/lit-analyzer/node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"dev": true,
@@ -1274,12 +1150,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/lodash.deburr": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
-			"integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
-			"dev": true
 		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
@@ -1603,12 +1473,6 @@
 				"semver": "^5.1.0"
 			}
 		},
-		"node_modules/parse5": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
-			"dev": true
-		},
 		"node_modules/parse5-htmlparser2-tree-adapter": {
 			"version": "6.0.1",
 			"dev": true,
@@ -1797,12 +1661,6 @@
 			"engines": {
 				"node": ">=8.10.0"
 			}
-		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-			"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-			"dev": true
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -2086,12 +1944,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/ts-simple-type": {
-			"version": "2.0.0-next.0",
-			"resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-2.0.0-next.0.tgz",
-			"integrity": "sha512-A+hLX83gS+yH6DtzNAhzZbPfU+D9D8lHlTSd7GeoMRBjOt3GRylDqLTYbdmjA4biWvq2xSfpqfIDj2l0OA/BVg==",
-			"dev": true
-		},
 		"node_modules/tslib": {
 			"version": "2.3.1",
 			"dev": true,
@@ -2264,155 +2116,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/vscode-css-languageservice": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-4.3.0.tgz",
-			"integrity": "sha512-BkQAMz4oVHjr0oOAz5PdeE72txlLQK7NIwzmclfr+b6fj6I8POwB+VoXvrZLTbWt9hWRgfvgiQRkh5JwrjPJ5A==",
-			"dev": true,
-			"dependencies": {
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^4.1.2",
-				"vscode-uri": "^2.1.2"
-			}
-		},
-		"node_modules/vscode-html-languageservice": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-3.1.0.tgz",
-			"integrity": "sha512-QAyRHI98bbEIBCqTzZVA0VblGU40na0txggongw5ZgTj9UVsVk5XbLT16O9OTcbqBGSqn0oWmFDNjK/XGIDcqg==",
-			"dev": true,
-			"dependencies": {
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^4.1.2",
-				"vscode-uri": "^2.1.2"
-			}
-		},
-		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
-			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA==",
-			"dev": true
-		},
-		"node_modules/vscode-languageserver-types": {
-			"version": "3.16.0-next.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
-			"integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==",
-			"dev": true
-		},
-		"node_modules/vscode-nls": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
-			"integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw==",
-			"dev": true
-		},
-		"node_modules/vscode-uri": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
-			"integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==",
-			"dev": true
-		},
-		"node_modules/web-component-analyzer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0.tgz",
-			"integrity": "sha512-UEvwfpD+XQw99sLKiH5B1T4QwpwNyWJxp59cnlRwFfhUW6JsQpw5jMeMwi7580sNou8YL3kYoS7BWLm+yJ/jVQ==",
-			"dev": true,
-			"dependencies": {
-				"fast-glob": "^3.2.2",
-				"ts-simple-type": "2.0.0-next.0",
-				"typescript": "~5.2.0",
-				"yargs": "^17.7.2"
-			},
-			"bin": {
-				"wca": "cli.js",
-				"web-component-analyzer": "cli.js"
-			}
-		},
-		"node_modules/web-component-analyzer/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/web-component-analyzer/node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/web-component-analyzer/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/web-component-analyzer/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/web-component-analyzer/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/web-component-analyzer/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/web-component-analyzer/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/which": {
@@ -2660,15 +2363,6 @@
 		}
 	},
 	"dependencies": {
-		"@babel/runtime": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-			"integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
-			"dev": true,
-			"requires": {
-				"regenerator-runtime": "^0.14.0"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"dev": true,
@@ -2705,12 +2399,6 @@
 		},
 		"@ungap/promise-all-settled": {
 			"version": "1.1.2",
-			"dev": true
-		},
-		"@vscode/web-custom-data": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/@vscode/web-custom-data/-/web-custom-data-0.4.8.tgz",
-			"integrity": "sha512-rRiEeEX49wipCeGZo65mQJUEuCY3IXd6bet90eY6cMMQ9jBe2g3Njw/2ctbaxuACPnEKXTdW0dB7umxDln3Rzg==",
 			"dev": true
 		},
 		"ansi-colors": {
@@ -3020,17 +2708,6 @@
 		"detect-libc": {
 			"version": "2.0.1",
 			"dev": true
-		},
-		"didyoumean2": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/didyoumean2/-/didyoumean2-4.1.0.tgz",
-			"integrity": "sha512-qTBmfQoXvhKO75D/05C8m+fteQmn4U46FWYiLhXtZQInzitXLWY0EQ/2oKnpAz9g2lQWW8jYcLcT+hPJGT+kig==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.10.2",
-				"leven": "^3.1.0",
-				"lodash.deburr": "^4.1.0"
-			}
 		},
 		"diff": {
 			"version": "5.0.0",
@@ -3380,93 +3057,12 @@
 				"uc.micro": "^1.0.1"
 			}
 		},
-		"lit-analyzer": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/lit-analyzer/-/lit-analyzer-2.0.1.tgz",
-			"integrity": "sha512-4bHJLCbxywMHd9bnVkLDkCSHXs/KrlwUks75EhYtJNdzH07O5BSVdZdadbw4T2AvuYxb0xRO4ZjqgQJCkp8Kjg==",
-			"dev": true,
-			"requires": {
-				"@vscode/web-custom-data": "^0.4.2",
-				"chalk": "^2.4.2",
-				"didyoumean2": "4.1.0",
-				"fast-glob": "^3.2.11",
-				"parse5": "5.1.0",
-				"ts-simple-type": "~2.0.0-next.0",
-				"vscode-css-languageservice": "4.3.0",
-				"vscode-html-languageservice": "3.1.0",
-				"web-component-analyzer": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-					"dev": true
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
 		"locate-path": {
 			"version": "6.0.0",
 			"dev": true,
 			"requires": {
 				"p-locate": "^5.0.0"
 			}
-		},
-		"lodash.deburr": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
-			"integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
-			"dev": true
 		},
 		"log-symbols": {
 			"version": "4.1.0",
@@ -3672,12 +3268,6 @@
 				"semver": "^5.1.0"
 			}
 		},
-		"parse5": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
-			"dev": true
-		},
 		"parse5-htmlparser2-tree-adapter": {
 			"version": "6.0.1",
 			"dev": true,
@@ -3804,12 +3394,6 @@
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
-		},
-		"regenerator-runtime": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-			"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-			"dev": true
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -3968,12 +3552,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"ts-simple-type": {
-			"version": "2.0.0-next.0",
-			"resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-2.0.0-next.0.tgz",
-			"integrity": "sha512-A+hLX83gS+yH6DtzNAhzZbPfU+D9D8lHlTSd7GeoMRBjOt3GRylDqLTYbdmjA4biWvq2xSfpqfIDj2l0OA/BVg==",
-			"dev": true
-		},
 		"tslib": {
 			"version": "2.3.1",
 			"dev": true
@@ -4093,132 +3671,6 @@
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
-				}
-			}
-		},
-		"vscode-css-languageservice": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-4.3.0.tgz",
-			"integrity": "sha512-BkQAMz4oVHjr0oOAz5PdeE72txlLQK7NIwzmclfr+b6fj6I8POwB+VoXvrZLTbWt9hWRgfvgiQRkh5JwrjPJ5A==",
-			"dev": true,
-			"requires": {
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^4.1.2",
-				"vscode-uri": "^2.1.2"
-			}
-		},
-		"vscode-html-languageservice": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-3.1.0.tgz",
-			"integrity": "sha512-QAyRHI98bbEIBCqTzZVA0VblGU40na0txggongw5ZgTj9UVsVk5XbLT16O9OTcbqBGSqn0oWmFDNjK/XGIDcqg==",
-			"dev": true,
-			"requires": {
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^4.1.2",
-				"vscode-uri": "^2.1.2"
-			}
-		},
-		"vscode-languageserver-textdocument": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
-			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA==",
-			"dev": true
-		},
-		"vscode-languageserver-types": {
-			"version": "3.16.0-next.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
-			"integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==",
-			"dev": true
-		},
-		"vscode-nls": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
-			"integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw==",
-			"dev": true
-		},
-		"vscode-uri": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
-			"integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==",
-			"dev": true
-		},
-		"web-component-analyzer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0.tgz",
-			"integrity": "sha512-UEvwfpD+XQw99sLKiH5B1T4QwpwNyWJxp59cnlRwFfhUW6JsQpw5jMeMwi7580sNou8YL3kYoS7BWLm+yJ/jVQ==",
-			"dev": true,
-			"requires": {
-				"fast-glob": "^3.2.2",
-				"ts-simple-type": "2.0.0-next.0",
-				"typescript": "~5.2.0",
-				"yargs": "^17.7.2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-					"dev": true
-				},
-				"cliui": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-					"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.1",
-						"wrap-ansi": "^7.0.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.1"
-					}
-				},
-				"yargs": {
-					"version": "17.7.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-					"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-					"dev": true,
-					"requires": {
-						"cliui": "^8.0.1",
-						"escalade": "^3.1.1",
-						"get-caller-file": "^2.0.5",
-						"require-directory": "^2.1.1",
-						"string-width": "^4.2.3",
-						"y18n": "^5.0.5",
-						"yargs-parser": "^21.1.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "21.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-					"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-					"dev": true
 				}
 			}
 		},


### PR DESCRIPTION
* Updates the repo to typescript 4.8.4 - this is the minimum tested TS version anyway, and supports the correct use of `getNodeForUsageLocation` to properly determine `ModuleKind` for resolving modules.
* Updates use of `resolveModuleNameFromCache` to properly pass the right mode argument to resolve in more situations correctly.
* Updates required and default `compilerOptions` to not overwrite the project under tests tsconfig options if provided. Will still default to the original behavior, but will now obey whats in the `tsconfig.json` if its specified.
* Updates lots of package-locks which didn't seem to be up to date in `main` and were updated automatically.