### PR TITLE
Adds integration test for no-missing-import

### DIFF
--- a/packages/vscode-lit-plugin/src/test/fixtures/missing-import.ts
+++ b/packages/vscode-lit-plugin/src/test/fixtures/missing-import.ts
@@ -1,0 +1,5 @@
+import { html } from "lit-element";
+
+import "./my-other-element.js";
+
+html`<my-defined-element></my-defined-element><my-other-element></my-other-element>`;

--- a/packages/vscode-lit-plugin/src/test/fixtures/my-defined-element.ts
+++ b/packages/vscode-lit-plugin/src/test/fixtures/my-defined-element.ts
@@ -1,0 +1,9 @@
+export class MyDefinedElement extends HTMLElement {}
+
+customElements.define("my-defined-element", MyDefinedElement);
+
+declare global {
+	interface HTMLElementTagNameMap {
+		"my-defined-element": MyDefinedElement;
+	}
+}

--- a/packages/vscode-lit-plugin/src/test/fixtures/my-other-element.ts
+++ b/packages/vscode-lit-plugin/src/test/fixtures/my-other-element.ts
@@ -1,0 +1,9 @@
+export class MyOtherElement extends HTMLElement {}
+
+customElements.define("my-other-element", MyOtherElement);
+
+declare global {
+	interface HTMLElementTagNameMap {
+		"my-other-element": MyOtherElement;
+	}
+}

--- a/packages/vscode-lit-plugin/src/test/simple-test.ts
+++ b/packages/vscode-lit-plugin/src/test/simple-test.ts
@@ -46,6 +46,49 @@ suite("Extension Test Suite", () => {
 		);
 	});
 
+	test("We detect no-missing-import properly", async () => {
+		const config = vscode.workspace.getConfiguration();
+		config.update("lit-plugin.logging", "verbose", true);
+		config.update("lit-plugin.rules.no-missing-import", "error", true);
+		const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(__dirname, "../../src/test/fixtures/missing-import.ts")));
+		const editor = await vscode.window.showTextDocument(doc);
+
+		// wait until the TS language server is ready and diagnostics are produced
+		async function getDiagnostics() {
+			for (let i = 0; i < 1000; i++) {
+				const diagnostics = vscode.languages.getDiagnostics(doc.uri);
+				if (diagnostics.length > 0) {
+					return diagnostics;
+				}
+				// Is there a better way to wait for the ts server to be ready?
+				// Maybe we can listen for the event that displays and hides the "initializing TS/JS language features" message?
+				await new Promise(resolve => setTimeout(resolve, 100));
+			}
+			throw new Error("No diagnostics found");
+		}
+
+		const diagnostics = await getDiagnostics();
+		assert.deepStrictEqual(
+			diagnostics.map(d => d.message),
+			["Missing import for <my-defined-element>\n  You can disable this check by disabling the 'no-missing-import' rule."]
+		);
+
+		// now add the fix
+		const editRange = doc.lineAt(0).range.start;
+		editor.edit(builder => {
+			if (!editor) {
+				return;
+			}
+			editor.insertSnippet(new vscode.SnippetString("import './my-defined-element';\n"), editRange);
+		});
+
+		// give it some time to settle
+		await new Promise(resolve => setTimeout(resolve, 1000));
+
+		const diagnostics2 = await getDiagnostics();
+		assert.equal(diagnostics2.length, 0, "Expected no diagnostics after adding the import, received: " + diagnostics2.map(d => d.message));
+	});
+
 	test("We generate completions", async () => {
 		const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(__dirname, "../../src/test/fixtures/completions.ts")));
 		const editor = await vscode.window.showTextDocument(doc);


### PR DESCRIPTION
This adds an integration test for the vscode plugin to demonstrate the failure case for no-missing-import.

It loads a file with a missing import, and then adds the line into the editor for the import. This should fix all errors in the file, but instead we see a diagnostic for the other element in the page. It seems the extension is only resolving one import at a time.

This could be (and most likely is) a bug in lit-analyzer package itself, but only manifests in the extension where our TS state is dynamic. I'm guessing its a caching issue?