### PR TITLE
fix no-missing-import getting confused on incremental file changes

### DIFF
--- a/packages/lit-analyzer/src/lib/analyze/default-lit-analyzer-context.ts
+++ b/packages/lit-analyzer/src/lib/analyze/default-lit-analyzer-context.ts
@@ -285,6 +285,6 @@ export class DefaultLitAnalyzerContext implements LitAnalyzerContext {
 
 		// Build a graph of component dependencies
 		const res = parseDependencies(file, this);
-		this.dependencyStore.importedComponentDefinitionsInFile.set(file.fileName, res);
+		this.dependencyStore.absorbComponentDefinitionsForFile(file, res);
 	}
 }

--- a/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -168,6 +168,16 @@ function emitDirectModuleImportWithName(moduleSpecifier: string, node: Node, con
 		if (cache != null) {
 			result = context.ts.resolveModuleNameFromCache(moduleSpecifier, node.getSourceFile().fileName, cache, mode);
 		}
+		if (result == null) {
+			// Result could not be found from the cache, try and resolve module without using the
+			// cache.
+			result = context.ts.resolveModuleName(
+				moduleSpecifier,
+				node.getSourceFile().fileName,
+				context.program.getCompilerOptions(),
+				context.ts.createCompilerHost(context.program.getCompilerOptions())
+			);
+		}
 	}
 
 	if (result?.resolvedModule?.resolvedFileName != null) {

--- a/packages/lit-analyzer/src/lib/analyze/store/analyzer-dependency-store.ts
+++ b/packages/lit-analyzer/src/lib/analyze/store/analyzer-dependency-store.ts
@@ -1,20 +1,3 @@
 export interface AnalyzerDependencyStore {
 	hasTagNameBeenImported(fileName: string, tagName: string): boolean;
 }
-
-//importedComponentDefinitionsInFile = new Map<string, ComponentDefinition[]>();
-
-/**
- * Returns if a component for a specific file has been imported.
- * @param fileName
- * @param tagName
- */
-/*hasTagNameBeenImported(fileName: string, tagName: string): boolean {
- for (const file of this.importedComponentDefinitionsInFile.get(fileName) || []) {
- if (file.tagName === tagName) {
- return true;
- }
- }
-
- return false;
- }*/

--- a/packages/lit-analyzer/src/lib/analyze/store/dependency-store/default-analyzer-dependency-store.ts
+++ b/packages/lit-analyzer/src/lib/analyze/store/dependency-store/default-analyzer-dependency-store.ts
@@ -3,7 +3,7 @@ import { ComponentDefinition } from "web-component-analyzer";
 import { AnalyzerDependencyStore } from "../analyzer-dependency-store.js";
 
 export class DefaultAnalyzerDependencyStore implements AnalyzerDependencyStore {
-	importedComponentDefinitionsInFile = new Map<string, ComponentDefinition[]>();
+	private importedComponentDefinitionsInFile = new Map<string, ComponentDefinition[]>();
 
 	absorbComponentDefinitionsForFile(sourceFile: SourceFile, result: ComponentDefinition[]): void {
 		this.importedComponentDefinitionsInFile.set(sourceFile.fileName, result);

--- a/packages/vscode-lit-plugin/src/test/fixtures/missing-import.ts
+++ b/packages/vscode-lit-plugin/src/test/fixtures/missing-import.ts
@@ -1,0 +1,7 @@
+import "./my-defined-element.js";
+
+// Pretending this is the Lit html function
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const html: any;
+
+html`<my-defined-element></my-defined-element><my-other-element></my-other-element>`;

--- a/packages/vscode-lit-plugin/src/test/fixtures/my-defined-element.ts
+++ b/packages/vscode-lit-plugin/src/test/fixtures/my-defined-element.ts
@@ -1,0 +1,9 @@
+export class MyDefinedElement extends HTMLElement {}
+
+customElements.define("my-defined-element", MyDefinedElement);
+
+declare global {
+	interface HTMLElementTagNameMap {
+		"my-defined-element": MyDefinedElement;
+	}
+}

--- a/packages/vscode-lit-plugin/src/test/fixtures/my-other-element.ts
+++ b/packages/vscode-lit-plugin/src/test/fixtures/my-other-element.ts
@@ -1,0 +1,9 @@
+export class MyOtherElement extends HTMLElement {}
+
+customElements.define("my-other-element", MyOtherElement);
+
+declare global {
+	interface HTMLElementTagNameMap {
+		"my-other-element": MyOtherElement;
+	}
+}


### PR DESCRIPTION
### Context

See the following video to preview the issue:

https://github.com/runem/lit-analyzer/assets/15080861/c9eb6c43-1f1c-4b14-a012-79622a29a7ac

This screen recording captures the integration test created by @benjamind in https://github.com/runem/lit-analyzer/pull/335

### Fix

This was a rough issue to debug. Ultimately the TypeScript cache seems to sometimes not contain the files required to resolve the module specifier string. The fix is to handle this case by resolving the module specifier without using the cache.

This graceful fallback causes the integration test to pass. I also manually verified that the fix works.

### Other changes

I also did a small amount of cleanup removing some commented out code and tiny changes as I had to go pretty deep to find this issue.