### PR TITLE
Update no-nullable-attribute-binding fix for null attribute

### DIFF
--- a/packages/lit-analyzer/src/test/rules/no-nullable-attribute-binding.ts
+++ b/packages/lit-analyzer/src/test/rules/no-nullable-attribute-binding.ts
@@ -25,3 +25,17 @@ tsTest("Can assign 'null' in property binding", t => {
 	const { diagnostics } = getDiagnostics('html`<input .selectionEnd="${{} as number | null}" />`');
 	hasNoDiagnostics(t, diagnostics);
 });
+
+tsTest("Message for 'null' in attribute detects null type correctly", t => {
+	const { diagnostics } = getDiagnostics('html`<input maxlength="${{} as number | null}" />`');
+	hasDiagnostic(t, diagnostics, "no-nullable-attribute-binding");
+
+	t.true(diagnostics[0].message.includes("can end up binding the string 'null'"));
+});
+
+tsTest("Message for 'undefined' in attribute detects undefined type correctly", t => {
+	const { diagnostics } = getDiagnostics('html`<input maxlength="${{} as number | undefined}" />`');
+	hasDiagnostic(t, diagnostics, "no-nullable-attribute-binding");
+
+	t.true(diagnostics[0].message.includes("can end up binding the string 'undefined'"));
+});


### PR DESCRIPTION
### Context

Fixes: https://github.com/runem/lit-analyzer/issues/317

In versions of Lit >2, `ifDefined` can handle `null` and `undefined` so the explicit `null` check is no longer required.

### Change

Instead of recommending `ifDefined(expr === null ? undefined : expr)`, instead recommend `ifDefined(expr)` for both `undefined` and `null`.

### Test

Added message tests to ensure that type detection works correctly, and that the diagnostic message correctly identify either `null` or `undefined`. This will make it easier to catch regressions when moving to `isTypeAssignableTo` in the future.