### PR TITLE
Make `isSelfClosed` check more explicit

### DIFF
--- a/packages/lit-analyzer/src/lib/analyze/types/html-node/html-node-types.ts
+++ b/packages/lit-analyzer/src/lib/analyze/types/html-node/html-node-types.ts
@@ -20,6 +20,10 @@ export interface IHtmlNodeBase {
 	attributes: HtmlNodeAttr[];
 	parent?: HtmlNode;
 	children: HtmlNode[];
+	/**
+	 * Is true when an HTML node is either a void element, or was
+	 * explicitly closed with self-closing XML syntax.
+	 */
 	selfClosed: boolean;
 	document: HtmlDocument;
 }

--- a/packages/lit-analyzer/src/lib/rules/no-unclosed-tag.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-unclosed-tag.ts
@@ -11,7 +11,11 @@ const rule: RuleModule = {
 		priority: "low"
 	},
 	visitHtmlNode(htmlNode, context) {
-		if (!htmlNode.selfClosed && htmlNode.location.endTag == null) {
+		const {
+			selfClosed,
+			location: { endTag }
+		} = htmlNode;
+		if (!selfClosed && endTag == null) {
 			// Report specifically that a custom element cannot be self closing
 			//   if the user is trying to close a custom element.
 			const isCustomElement = isCustomElementTagName(htmlNode.tagName);

--- a/packages/lit-analyzer/src/test/rules/no-unclosed-tag.ts
+++ b/packages/lit-analyzer/src/test/rules/no-unclosed-tag.ts
@@ -11,3 +11,33 @@ tsTest("Don't report self closed tags", t => {
 	const { diagnostics } = getDiagnostics("html`<img />`", { rules: { "no-unclosed-tag": true } });
 	hasNoDiagnostics(t, diagnostics);
 });
+
+tsTest("Don't report void tags", t => {
+	const { diagnostics } = getDiagnostics("html`<img>`", { rules: { "no-unclosed-tag": true } });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+// The `<p>` tag will be closed automatically if immediately followed by a lot of other elements,
+// including `<div>`.
+// Ref: https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element
+tsTest("Report unclosed 'p' tag that is implicitly closed via tag omission", t => {
+	const { diagnostics } = getDiagnostics("html`<p><div></div></p>`", { rules: { "no-unclosed-tag": true } });
+	hasDiagnostic(t, diagnostics, "no-unclosed-tag");
+});
+
+tsTest("Report unclosed 'p' tag that is implicitly closed via tag omission containing text content", t => {
+	const { diagnostics } = getDiagnostics("html`<p>Unclosed Content<div></div></p>`", { rules: { "no-unclosed-tag": true } });
+	hasDiagnostic(t, diagnostics, "no-unclosed-tag");
+});
+
+// Self-closing tags do not exist in HTML, but we can use them to check
+// that the user intended that the tag be closed.
+tsTest("Don't report self closing 'p' tag", t => {
+	const { diagnostics } = getDiagnostics("html`<p /><div></div>`", { rules: { "no-unclosed-tag": true } });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("Don't report self closing 'p' tag containing text content", t => {
+	const { diagnostics } = getDiagnostics("html`<p />Unclosed Content<div></div>`", { rules: { "no-unclosed-tag": true } });
+	hasNoDiagnostics(t, diagnostics);
+});


### PR DESCRIPTION
### Context

This was inspired (and maybe closes) https://github.com/runem/lit-analyzer/issues/283.

This may be the wrong direction for fixing the linked issue, however I wanted to propose a solution after my investigation.

### Current check

The current `no-unclosed-tag` check grabs the source code locations for the tag from `parse5`, and then tries to guess if the tag was closed.

The tag _is marked as self closing_ if the node has **no children** and the `startTag.endOffset === node.endOffset`.

An important note here, is that the source code locations are taken from `parse5`, which behaves similarly to the browser and thus has special parsing rules for various tags.

The edge case can be seen with `<p>` which can be closed implicitly.

```html
<p><div></div><!--becomes:--><p></p><div></div>
<p>Some content<div></div><!--becomes:--><p>Some content</p><div></div>
```

Currently, the first case without content will not raise the `no-unclosed-tag` check, but the second case does raise the `no-unclosed-tag` check.

Why? Because `parse5` correctly creates the DOM `<p>Some content</p><div></div>`, but then there is no reference to an authored closing tag, and the presence of child content fails to mark the tag as self closing.

### Possible change

This PR introduces a possible change where the intent of self closing can be marked by adding `/>`. Therefore implicit closing tags result in the `no-unclosed-tag` diagnostic being raised. To mark a tag as explicit, add the `/>` syntax (which FYI isn't a valid HTML syntax).

### Risk

This will catch more cases, so I'm not very stoked about this idea. I'm also not excited by the general concept of "self-closing" syntax which this PR pushes forward.