### PR TITLE
Update CSS and HTML Language Service versions

### DIFF
--- a/packages/lit-analyzer/package-lock.json
+++ b/packages/lit-analyzer/package-lock.json
@@ -15,7 +15,7 @@
 				"fast-glob": "^3.2.11",
 				"parse5": "5.1.0",
 				"ts-simple-type": "~2.0.0-next.0",
-				"vscode-css-languageservice": "4.3.0",
+				"vscode-css-languageservice": "6.2.12",
 				"vscode-html-languageservice": "3.1.0",
 				"web-component-analyzer": "^2.0.0"
 			},
@@ -373,6 +373,11 @@
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
 			"dev": true
+		},
+		"node_modules/@vscode/l10n": {
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+			"integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="
 		},
 		"node_modules/@vscode/web-custom-data": {
 			"version": "0.4.2",
@@ -3860,15 +3865,25 @@
 			}
 		},
 		"node_modules/vscode-css-languageservice": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-4.3.0.tgz",
-			"integrity": "sha512-BkQAMz4oVHjr0oOAz5PdeE72txlLQK7NIwzmclfr+b6fj6I8POwB+VoXvrZLTbWt9hWRgfvgiQRkh5JwrjPJ5A==",
+			"version": "6.2.12",
+			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.12.tgz",
+			"integrity": "sha512-PS9r7HgNjqzRl3v91sXpCyZPc8UDotNo6gntFNtGCKPhGA9Frk7g/VjX1Mbv3F00pn56D+rxrFzR9ep4cawOgA==",
 			"dependencies": {
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^4.1.2",
-				"vscode-uri": "^2.1.2"
+				"@vscode/l10n": "^0.0.18",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-types": "3.17.5",
+				"vscode-uri": "^3.0.8"
 			}
+		},
+		"node_modules/vscode-css-languageservice/node_modules/vscode-languageserver-types": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+		},
+		"node_modules/vscode-css-languageservice/node_modules/vscode-uri": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
 		},
 		"node_modules/vscode-html-languageservice": {
 			"version": "3.1.0",
@@ -3882,9 +3897,9 @@
 			}
 		},
 		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz",
-			"integrity": "sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ=="
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
+			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
 		},
 		"node_modules/vscode-languageserver-types": {
 			"version": "3.16.0-next.2",
@@ -4367,6 +4382,11 @@
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
 			"dev": true
+		},
+		"@vscode/l10n": {
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+			"integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="
 		},
 		"@vscode/web-custom-data": {
 			"version": "0.4.2",
@@ -6928,14 +6948,26 @@
 			}
 		},
 		"vscode-css-languageservice": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-4.3.0.tgz",
-			"integrity": "sha512-BkQAMz4oVHjr0oOAz5PdeE72txlLQK7NIwzmclfr+b6fj6I8POwB+VoXvrZLTbWt9hWRgfvgiQRkh5JwrjPJ5A==",
+			"version": "6.2.12",
+			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.12.tgz",
+			"integrity": "sha512-PS9r7HgNjqzRl3v91sXpCyZPc8UDotNo6gntFNtGCKPhGA9Frk7g/VjX1Mbv3F00pn56D+rxrFzR9ep4cawOgA==",
 			"requires": {
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^4.1.2",
-				"vscode-uri": "^2.1.2"
+				"@vscode/l10n": "^0.0.18",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-types": "3.17.5",
+				"vscode-uri": "^3.0.8"
+			},
+			"dependencies": {
+				"vscode-languageserver-types": {
+					"version": "3.17.5",
+					"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+					"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+				},
+				"vscode-uri": {
+					"version": "3.0.8",
+					"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+					"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
+				}
 			}
 		},
 		"vscode-html-languageservice": {
@@ -6950,9 +6982,9 @@
 			}
 		},
 		"vscode-languageserver-textdocument": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz",
-			"integrity": "sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ=="
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
+			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
 		},
 		"vscode-languageserver-types": {
 			"version": "3.16.0-next.2",

--- a/packages/lit-analyzer/package-lock.json
+++ b/packages/lit-analyzer/package-lock.json
@@ -16,7 +16,7 @@
 				"parse5": "5.1.0",
 				"ts-simple-type": "~2.0.0-next.0",
 				"vscode-css-languageservice": "6.2.12",
-				"vscode-html-languageservice": "3.1.0",
+				"vscode-html-languageservice": "5.1.2",
 				"web-component-analyzer": "^2.0.0"
 			},
 			"bin": {
@@ -3875,25 +3875,15 @@
 				"vscode-uri": "^3.0.8"
 			}
 		},
-		"node_modules/vscode-css-languageservice/node_modules/vscode-languageserver-types": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
-		},
-		"node_modules/vscode-css-languageservice/node_modules/vscode-uri": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
-		},
 		"node_modules/vscode-html-languageservice": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-3.1.0.tgz",
-			"integrity": "sha512-QAyRHI98bbEIBCqTzZVA0VblGU40na0txggongw5ZgTj9UVsVk5XbLT16O9OTcbqBGSqn0oWmFDNjK/XGIDcqg==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.1.2.tgz",
+			"integrity": "sha512-wkWfEx/IIR3s2P5yD4aTGHiOb8IAzFxgkSt1uSC3itJ4oDAm23yG7o0L29JljUdnXDDgLafPAvhv8A2I/8riHw==",
 			"dependencies": {
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^4.1.2",
-				"vscode-uri": "^2.1.2"
+				"@vscode/l10n": "^0.0.18",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-types": "^3.17.5",
+				"vscode-uri": "^3.0.8"
 			}
 		},
 		"node_modules/vscode-languageserver-textdocument": {
@@ -3902,19 +3892,14 @@
 			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
 		},
 		"node_modules/vscode-languageserver-types": {
-			"version": "3.16.0-next.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
-			"integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q=="
-		},
-		"node_modules/vscode-nls": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
-			"integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
 		},
 		"node_modules/vscode-uri": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
-			"integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
 		},
 		"node_modules/wcwidth": {
 			"version": "1.0.1",
@@ -6956,29 +6941,17 @@
 				"vscode-languageserver-textdocument": "^1.0.11",
 				"vscode-languageserver-types": "3.17.5",
 				"vscode-uri": "^3.0.8"
-			},
-			"dependencies": {
-				"vscode-languageserver-types": {
-					"version": "3.17.5",
-					"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-					"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
-				},
-				"vscode-uri": {
-					"version": "3.0.8",
-					"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-					"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
-				}
 			}
 		},
 		"vscode-html-languageservice": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-3.1.0.tgz",
-			"integrity": "sha512-QAyRHI98bbEIBCqTzZVA0VblGU40na0txggongw5ZgTj9UVsVk5XbLT16O9OTcbqBGSqn0oWmFDNjK/XGIDcqg==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.1.2.tgz",
+			"integrity": "sha512-wkWfEx/IIR3s2P5yD4aTGHiOb8IAzFxgkSt1uSC3itJ4oDAm23yG7o0L29JljUdnXDDgLafPAvhv8A2I/8riHw==",
 			"requires": {
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^4.1.2",
-				"vscode-uri": "^2.1.2"
+				"@vscode/l10n": "^0.0.18",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-types": "^3.17.5",
+				"vscode-uri": "^3.0.8"
 			}
 		},
 		"vscode-languageserver-textdocument": {
@@ -6987,19 +6960,14 @@
 			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
 		},
 		"vscode-languageserver-types": {
-			"version": "3.16.0-next.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
-			"integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q=="
-		},
-		"vscode-nls": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
-			"integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
 		},
 		"vscode-uri": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
-			"integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
 		},
 		"wcwidth": {
 			"version": "1.0.1",

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -94,7 +94,7 @@
 		"fast-glob": "^3.2.11",
 		"parse5": "5.1.0",
 		"ts-simple-type": "~2.0.0-next.0",
-		"vscode-css-languageservice": "4.3.0",
+		"vscode-css-languageservice": "6.2.12",
 		"vscode-html-languageservice": "3.1.0",
 		"web-component-analyzer": "^2.0.0"
 	},

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -95,7 +95,7 @@
 		"parse5": "5.1.0",
 		"ts-simple-type": "~2.0.0-next.0",
 		"vscode-css-languageservice": "6.2.12",
-		"vscode-html-languageservice": "3.1.0",
+		"vscode-html-languageservice": "5.1.2",
 		"web-component-analyzer": "^2.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
This is a pretty simple PR. I updated the CSS and HTML Language Service packages to their latest release. The current locked versions are from mid 2020, and there have been many new features like the `accent-color` CSS attribute that prompted this work.

This fixes #314, most likely #146, potentially #326, #132, #284, and #259 (but I haven't tested it).

I also updated the TypeScript version to 5.3.3, and added the appropriate compatibility checks to the test suite for 5.2 and 5.3.