### PR TITLE
Return the text with the typehint information if it is available

### DIFF
--- a/packages/lit-analyzer/src/lib/analyze/parse/parse-html-data/html-tag.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/parse-html-data/html-tag.ts
@@ -222,6 +222,9 @@ export function targetKindAndTypeText(target: HtmlAttrTarget, options: Descripti
 	const prefix = `(${targetKindText(target)}) ${options.modifier || ""}${target.name}`;
 
 	if (isAssignableToSimpleTypeKind(target.getType(), "ANY")) {
+		if(target.declaration?.typeHint){
+			return `${prefix}: ${target.declaration.typeHint}`
+		}
 		return `${prefix}`;
 	}
 


### PR DESCRIPTION
The webcomponent analyzer returns a typehint string we can display that if it is present and there isn't any simpletype information