### PR TITLE
Add a test that the no-nullable-attribute-binding fix suggestion actually works.

### DIFF
--- a/packages/lit-analyzer/src/test/rules/no-nullable-attribute-binding.ts
+++ b/packages/lit-analyzer/src/test/rules/no-nullable-attribute-binding.ts
@@ -21,6 +21,16 @@ tsTest("Cannot assign 'null' in attribute binding", t => {
 	hasDiagnostic(t, diagnostics, "no-nullable-attribute-binding");
 });
 
+tsTest("Can pass 'null' through ifDefined in attribute binding", t => {
+	const { diagnostics } = getDiagnostics('import {ifDefined} from "lit/directives/if-defined.js";\nhtml`<input maxlength="${ifDefined({} as number | null)}" />`');
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("Can pass 'null' through ??nothing in attribute binding", t => {
+	const { diagnostics } = getDiagnostics('html`<input maxlength="${({} as number | null) ?? nothing}" />`');
+	hasNoDiagnostics(t, diagnostics);
+});
+
 tsTest("Can assign 'null' in property binding", t => {
 	const { diagnostics } = getDiagnostics('html`<input .selectionEnd="${{} as number | null}" />`');
 	hasNoDiagnostics(t, diagnostics);

--- a/packages/lit-analyzer/src/test/rules/no-nullable-attribute-binding.ts
+++ b/packages/lit-analyzer/src/test/rules/no-nullable-attribute-binding.ts
@@ -22,7 +22,9 @@ tsTest("Cannot assign 'null' in attribute binding", t => {
 });
 
 tsTest("Can pass 'null' through ifDefined in attribute binding", t => {
-	const { diagnostics } = getDiagnostics('import {ifDefined} from "lit/directives/if-defined.js";\nhtml`<input maxlength="${ifDefined({} as number | null)}" />`');
+	const { diagnostics } = getDiagnostics(
+		'import {ifDefined} from "lit/directives/if-defined.js";\nhtml`<input maxlength="${ifDefined({} as number | null)}" />`'
+	);
 	hasNoDiagnostics(t, diagnostics);
 });
 


### PR DESCRIPTION
This is a test to go with whatever fix is developed for #253. It can't be submitted as-is since it currently fails. It also demonstrates a workaround for the bug: use `??nothing` instead of `ifDefined`.