### PR TITLE
Exclude symbols when checking binding types

### DIFF
--- a/packages/lit-analyzer/src/lib/rules/util/type/extract-binding-types.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/type/extract-binding-types.ts
@@ -50,6 +50,10 @@ export function extractBindingTypes(assignment: HtmlNodeAttrAssignment, context:
 		typeB = directiveType;
 	}
 
+	// Handle `nothing` and `noChange` symbols
+	// Since it's not possible to check the details of a symbol due to various restrictions (it's treated as a `unique symbol` or `Symbol()`), all symbols are excluded.
+	typeB = excludeSymbolsFromUnion(typeB);
+
 	// Cache the result
 	const result = { typeA, typeB };
 	cache.set(assignment, result);
@@ -80,6 +84,17 @@ export function inferTypeFromAssignment(assignment: HtmlNodeAttrAssignment, chec
 
 			return { kind: "STRING" } as SimpleTypeString;
 	}
+}
+
+function excludeSymbolsFromUnion(type: SimpleType): SimpleType {
+	if (type.kind !== "UNION") {
+		return type;
+	}
+
+	return {
+		...type,
+		types: type.types.filter(t => t.kind !== "ES_SYMBOL" && t.kind !== "ES_SYMBOL_UNIQUE")
+	};
 }
 
 /**

--- a/packages/lit-analyzer/src/test/helpers/compile-files.ts
+++ b/packages/lit-analyzer/src/test/helpers/compile-files.ts
@@ -105,7 +105,17 @@ export function compileFiles(inputFiles: TestFile[] | TestFile = []): { program:
 
 	const program = ts.createProgram({
 		//rootNames: [...files.map(file => file.fileName!), "node_modules/typescript/lib/lib.dom.d.ts"],
-		rootNames: [...files.map(file => file.fileName!), ...(includeLib ? ["node_modules/typescript/lib/lib.dom.d.ts"] : [])],
+		rootNames: [
+			...files.map(file => file.fileName!),
+			...(includeLib
+				? [
+						"node_modules/typescript/lib/lib.dom.d.ts",
+						// We need this to enable `Symbol`.
+						// We cannot use "esnext" since it cannot be loaded by TS 4.8.4.
+						"node_modules/typescript/lib/lib.es2015.d.ts"
+				  ]
+				: [])
+		],
 		//rootNames: files.map(file => file.fileName!),
 		options: compilerOptions,
 		host: compilerHost

--- a/packages/lit-analyzer/src/test/rules/no-incompatible-type-binding.ts
+++ b/packages/lit-analyzer/src/test/rules/no-incompatible-type-binding.ts
@@ -293,3 +293,39 @@ tsTest("Attribute binding: the target attribute is correctly type checked when g
 
 	hasNoDiagnostics(t, diagnostics);
 });
+
+tsTest("Attribute binding: any symbols are ignored on type checking", t => {
+	const { diagnostics } = getDiagnostics(`
+declare const value: boolean | unique symbol;
+
+html\`<div aria-expanded=\${userInput}></div>\`
+	`);
+
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("Attribute binding: symbols are not treated as any type", t => {
+	const { diagnostics } = getDiagnostics(`
+declare const value: "invalid" | unique symbol;
+
+html\`<div aria-expanded=\${value}></div>\`
+	`);
+
+	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
+});
+
+tsTest("Attribute binding: lit's nothing is ignored on type checking when returned by a function", t => {
+	const { diagnostics } = getDiagnostics(`
+declare const nothing: unique symbol;
+
+function customIfDef<T>(value: T | null | undefined): T | typeof nothing {
+	return value ?? nothing;
+}
+
+declare const value: boolean | null;
+
+html\`<div aria-expanded=\${customIfDef(value)}></div>\`
+	`);
+
+	hasNoDiagnostics(t, diagnostics);
+});


### PR DESCRIPTION
This PR excludes ES symbol types from unions when checking bindings.
This ensures that `nothing` and `noChange` are ignored in type checking.

We remove all symbol types because it is not possible to get the details of symbol types.
This will produce false negatives when other symbols are mixed in, but I consider such situations to be rare.

Closes #207. Closes #251. Closes #316.

This PR does not resolve the issue of `ifDefined` not supporting `null` (even though Lit v3 does).
It will probably be resolved when we stop treating `ifDefined` specially, or when #296 is merged.
The user can use either a custom directive or `value ?? nothing` instead of `ifDefined` to workaround the issue.