### PR TITLE
Update dependencies: web-custom-data, parse5, vscode-{css,html}-languageservice

### DIFF
--- a/packages/lit-analyzer/package-lock.json
+++ b/packages/lit-analyzer/package-lock.json
@@ -9,14 +9,14 @@
 			"version": "2.0.3",
 			"license": "MIT",
 			"dependencies": {
-				"@vscode/web-custom-data": "^0.4.2",
+				"@vscode/web-custom-data": "^0.4.12",
 				"chalk": "^2.4.2",
 				"didyoumean2": "4.1.0",
 				"fast-glob": "^3.2.11",
-				"parse5": "5.1.0",
+				"parse5": "7.2.1",
 				"ts-simple-type": "~2.0.0-next.0",
-				"vscode-css-languageservice": "6.2.12",
-				"vscode-html-languageservice": "5.1.2",
+				"vscode-css-languageservice": "6.3.1",
+				"vscode-html-languageservice": "5.3.1",
 				"web-component-analyzer": "^2.0.0"
 			},
 			"bin": {
@@ -380,9 +380,10 @@
 			"integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="
 		},
 		"node_modules/@vscode/web-custom-data": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@vscode/web-custom-data/-/web-custom-data-0.4.2.tgz",
-			"integrity": "sha512-A1jBlLJtOrQYBC1lefZXN2EURHo2cIu3lsQpctWNDfBmydorukhIgnfxTgGXIb+ZETQgrPgEqkWYLZAylMtJBw=="
+			"version": "0.4.12",
+			"resolved": "https://registry.npmjs.org/@vscode/web-custom-data/-/web-custom-data-0.4.12.tgz",
+			"integrity": "sha512-bCemuvwCC84wJQbJoaPou86sjz9DUvZgGa6sAWQwzw7oIELD7z+WnUj2Rdsu8/8XPhKLcg3IswQ2+Pm3OMinIg==",
+			"license": "MIT"
 		},
 		"node_modules/acorn": {
 			"version": "8.7.0",
@@ -1419,6 +1420,18 @@
 			"dev": true,
 			"dependencies": {
 				"once": "^1.4.0"
+			}
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/equal-length": {
@@ -2776,9 +2789,16 @@
 			}
 		},
 		"node_modules/parse5": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+			"integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^4.5.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
 		},
 		"node_modules/path": {
 			"version": "0.12.7",
@@ -3865,31 +3885,34 @@
 			}
 		},
 		"node_modules/vscode-css-languageservice": {
-			"version": "6.2.12",
-			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.12.tgz",
-			"integrity": "sha512-PS9r7HgNjqzRl3v91sXpCyZPc8UDotNo6gntFNtGCKPhGA9Frk7g/VjX1Mbv3F00pn56D+rxrFzR9ep4cawOgA==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.1.tgz",
+			"integrity": "sha512-1BzTBuJfwMc3A0uX4JBdJgoxp74cjj4q2mDJdp49yD/GuAq4X0k5WtK6fNcMYr+FfJ9nqgR6lpfCSZDkARJ5qQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@vscode/l10n": "^0.0.18",
-				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-textdocument": "^1.0.12",
 				"vscode-languageserver-types": "3.17.5",
 				"vscode-uri": "^3.0.8"
 			}
 		},
 		"node_modules/vscode-html-languageservice": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.1.2.tgz",
-			"integrity": "sha512-wkWfEx/IIR3s2P5yD4aTGHiOb8IAzFxgkSt1uSC3itJ4oDAm23yG7o0L29JljUdnXDDgLafPAvhv8A2I/8riHw==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.3.1.tgz",
+			"integrity": "sha512-ysUh4hFeW/WOWz/TO9gm08xigiSsV/FOAZ+DolgJfeLftna54YdmZ4A+lIn46RbdO3/Qv5QHTn1ZGqmrXQhZyA==",
+			"license": "MIT",
 			"dependencies": {
 				"@vscode/l10n": "^0.0.18",
-				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-textdocument": "^1.0.12",
 				"vscode-languageserver-types": "^3.17.5",
 				"vscode-uri": "^3.0.8"
 			}
 		},
 		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
-			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+			"license": "MIT"
 		},
 		"node_modules/vscode-languageserver-types": {
 			"version": "3.17.5",
@@ -4374,9 +4397,9 @@
 			"integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="
 		},
 		"@vscode/web-custom-data": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@vscode/web-custom-data/-/web-custom-data-0.4.2.tgz",
-			"integrity": "sha512-A1jBlLJtOrQYBC1lefZXN2EURHo2cIu3lsQpctWNDfBmydorukhIgnfxTgGXIb+ZETQgrPgEqkWYLZAylMtJBw=="
+			"version": "0.4.12",
+			"resolved": "https://registry.npmjs.org/@vscode/web-custom-data/-/web-custom-data-0.4.12.tgz",
+			"integrity": "sha512-bCemuvwCC84wJQbJoaPou86sjz9DUvZgGa6sAWQwzw7oIELD7z+WnUj2Rdsu8/8XPhKLcg3IswQ2+Pm3OMinIg=="
 		},
 		"acorn": {
 			"version": "8.7.0",
@@ -5152,6 +5175,11 @@
 			"requires": {
 				"once": "^1.4.0"
 			}
+		},
+		"entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
 		},
 		"equal-length": {
 			"version": "1.0.1",
@@ -6141,9 +6169,12 @@
 			"dev": true
 		},
 		"parse5": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+			"integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+			"requires": {
+				"entities": "^4.5.0"
+			}
 		},
 		"path": {
 			"version": "0.12.7",
@@ -6933,31 +6964,31 @@
 			}
 		},
 		"vscode-css-languageservice": {
-			"version": "6.2.12",
-			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.12.tgz",
-			"integrity": "sha512-PS9r7HgNjqzRl3v91sXpCyZPc8UDotNo6gntFNtGCKPhGA9Frk7g/VjX1Mbv3F00pn56D+rxrFzR9ep4cawOgA==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.1.tgz",
+			"integrity": "sha512-1BzTBuJfwMc3A0uX4JBdJgoxp74cjj4q2mDJdp49yD/GuAq4X0k5WtK6fNcMYr+FfJ9nqgR6lpfCSZDkARJ5qQ==",
 			"requires": {
 				"@vscode/l10n": "^0.0.18",
-				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-textdocument": "^1.0.12",
 				"vscode-languageserver-types": "3.17.5",
 				"vscode-uri": "^3.0.8"
 			}
 		},
 		"vscode-html-languageservice": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.1.2.tgz",
-			"integrity": "sha512-wkWfEx/IIR3s2P5yD4aTGHiOb8IAzFxgkSt1uSC3itJ4oDAm23yG7o0L29JljUdnXDDgLafPAvhv8A2I/8riHw==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.3.1.tgz",
+			"integrity": "sha512-ysUh4hFeW/WOWz/TO9gm08xigiSsV/FOAZ+DolgJfeLftna54YdmZ4A+lIn46RbdO3/Qv5QHTn1ZGqmrXQhZyA==",
 			"requires": {
 				"@vscode/l10n": "^0.0.18",
-				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-textdocument": "^1.0.12",
 				"vscode-languageserver-types": "^3.17.5",
 				"vscode-uri": "^3.0.8"
 			}
 		},
 		"vscode-languageserver-textdocument": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
-			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
 		},
 		"vscode-languageserver-types": {
 			"version": "3.17.5",

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -88,14 +88,14 @@
 		"cli.js"
 	],
 	"dependencies": {
-		"@vscode/web-custom-data": "^0.4.2",
+		"@vscode/web-custom-data": "^0.4.12",
 		"chalk": "^2.4.2",
 		"didyoumean2": "4.1.0",
 		"fast-glob": "^3.2.11",
-		"parse5": "5.1.0",
+		"parse5": "7.2.1",
 		"ts-simple-type": "~2.0.0-next.0",
-		"vscode-css-languageservice": "6.2.12",
-		"vscode-html-languageservice": "5.1.2",
+		"vscode-css-languageservice": "6.3.1",
+		"vscode-html-languageservice": "5.3.1",
 		"web-component-analyzer": "^2.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
This gets us the latest web standards.

This updates the dependencies for packages/lit-analyzer. Could we please also get new releases for vscode-lit-plugin and ts-lit-plugin that use the lit-analyzer with its updated dependencies?