### PR TITLE
Jrobards/update action workflows

### DIFF
--- a/.github/workflows/test_vscode.yml
+++ b/.github/workflows/test_vscode.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16.x
       - run: npm ci

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,14 +18,13 @@ jobs:
         node: [18, 20]
         exclude:
           - os: windows-latest
-            node: "17"
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 

--- a/packages/vscode-lit-plugin/package-lock.json
+++ b/packages/vscode-lit-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lit-plugin",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lit-plugin",
-			"version": "1.4.2",
+			"version": "1.4.3",
 			"license": "MIT",
 			"dependencies": {
 				"typescript": "~5.2.2"
@@ -16,12 +16,25 @@
 				"@types/node": "^14.0.13",
 				"@types/vscode": "^1.30.0",
 				"esbuild": "^0.14.36",
+				"lit-analyzer": "^2.0.3",
 				"mocha": "^9.1.4",
 				"vsce": "^2.7.0",
 				"wireit": "^0.1.1"
 			},
 			"engines": {
 				"vscode": "^1.63.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+			"integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.14.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -76,6 +89,12 @@
 			"version": "1.1.2",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/@vscode/web-custom-data": {
+			"version": "0.4.12",
+			"resolved": "https://registry.npmjs.org/@vscode/web-custom-data/-/web-custom-data-0.4.12.tgz",
+			"integrity": "sha512-bCemuvwCC84wJQbJoaPou86sjz9DUvZgGa6sAWQwzw7oIELD7z+WnUj2Rdsu8/8XPhKLcg3IswQ2+Pm3OMinIg==",
+			"dev": true
 		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.1",
@@ -217,11 +236,12 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -573,6 +593,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/didyoumean2": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/didyoumean2/-/didyoumean2-4.1.0.tgz",
+			"integrity": "sha512-qTBmfQoXvhKO75D/05C8m+fteQmn4U46FWYiLhXtZQInzitXLWY0EQ/2oKnpAz9g2lQWW8jYcLcT+hPJGT+kig==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.10.2",
+				"leven": "^3.1.0",
+				"lodash.deburr": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=10.13"
+			}
+		},
 		"node_modules/diff": {
 			"version": "5.0.0",
 			"dev": true,
@@ -762,9 +796,10 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -1065,8 +1100,9 @@
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -1137,6 +1173,97 @@
 				"uc.micro": "^1.0.1"
 			}
 		},
+		"node_modules/lit-analyzer": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/lit-analyzer/-/lit-analyzer-2.0.3.tgz",
+			"integrity": "sha512-XiAjnwVipNrKav7r3CSEZpWt+mwYxrhPRVC7h8knDmn/HWTzzWJvPe+mwBcL2brn4xhItAMzZhFC8tzzqHKmiQ==",
+			"dev": true,
+			"dependencies": {
+				"@vscode/web-custom-data": "^0.4.2",
+				"chalk": "^2.4.2",
+				"didyoumean2": "4.1.0",
+				"fast-glob": "^3.2.11",
+				"parse5": "5.1.0",
+				"ts-simple-type": "~2.0.0-next.0",
+				"vscode-css-languageservice": "4.3.0",
+				"vscode-html-languageservice": "3.1.0",
+				"web-component-analyzer": "^2.0.0"
+			},
+			"bin": {
+				"lit-analyzer": "cli.js"
+			}
+		},
+		"node_modules/lit-analyzer/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/lit-analyzer/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/lit-analyzer/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/lit-analyzer/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true
+		},
+		"node_modules/lit-analyzer/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/lit-analyzer/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/lit-analyzer/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"dev": true,
@@ -1150,6 +1277,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/lodash.deburr": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
+			"integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
+			"dev": true
 		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
@@ -1473,6 +1606,12 @@
 				"semver": "^5.1.0"
 			}
 		},
+		"node_modules/parse5": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+			"dev": true
+		},
 		"node_modules/parse5-htmlparser2-tree-adapter": {
 			"version": "6.0.1",
 			"dev": true,
@@ -1661,6 +1800,12 @@
 			"engines": {
 				"node": ">=8.10.0"
 			}
+		},
+		"node_modules/regenerator-runtime": {
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+			"dev": true
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -1935,14 +2080,21 @@
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
 			"engines": {
 				"node": ">=8.0"
 			}
+		},
+		"node_modules/ts-simple-type": {
+			"version": "2.0.0-next.0",
+			"resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-2.0.0-next.0.tgz",
+			"integrity": "sha512-A+hLX83gS+yH6DtzNAhzZbPfU+D9D8lHlTSd7GeoMRBjOt3GRylDqLTYbdmjA4biWvq2xSfpqfIDj2l0OA/BVg==",
+			"dev": true
 		},
 		"node_modules/tslib": {
 			"version": "2.3.1",
@@ -2116,6 +2268,155 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/vscode-css-languageservice": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-4.3.0.tgz",
+			"integrity": "sha512-BkQAMz4oVHjr0oOAz5PdeE72txlLQK7NIwzmclfr+b6fj6I8POwB+VoXvrZLTbWt9hWRgfvgiQRkh5JwrjPJ5A==",
+			"dev": true,
+			"dependencies": {
+				"vscode-languageserver-textdocument": "^1.0.1",
+				"vscode-languageserver-types": "3.16.0-next.2",
+				"vscode-nls": "^4.1.2",
+				"vscode-uri": "^2.1.2"
+			}
+		},
+		"node_modules/vscode-html-languageservice": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-3.1.0.tgz",
+			"integrity": "sha512-QAyRHI98bbEIBCqTzZVA0VblGU40na0txggongw5ZgTj9UVsVk5XbLT16O9OTcbqBGSqn0oWmFDNjK/XGIDcqg==",
+			"dev": true,
+			"dependencies": {
+				"vscode-languageserver-textdocument": "^1.0.1",
+				"vscode-languageserver-types": "3.16.0-next.2",
+				"vscode-nls": "^4.1.2",
+				"vscode-uri": "^2.1.2"
+			}
+		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+			"dev": true
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.16.0-next.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
+			"integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==",
+			"dev": true
+		},
+		"node_modules/vscode-nls": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
+			"integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw==",
+			"dev": true
+		},
+		"node_modules/vscode-uri": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
+			"integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==",
+			"dev": true
+		},
+		"node_modules/web-component-analyzer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0.tgz",
+			"integrity": "sha512-UEvwfpD+XQw99sLKiH5B1T4QwpwNyWJxp59cnlRwFfhUW6JsQpw5jMeMwi7580sNou8YL3kYoS7BWLm+yJ/jVQ==",
+			"dev": true,
+			"dependencies": {
+				"fast-glob": "^3.2.2",
+				"ts-simple-type": "2.0.0-next.0",
+				"typescript": "~5.2.0",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"wca": "cli.js",
+				"web-component-analyzer": "cli.js"
+			}
+		},
+		"node_modules/web-component-analyzer/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/web-component-analyzer/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/web-component-analyzer/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/web-component-analyzer/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/web-component-analyzer/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/web-component-analyzer/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/web-component-analyzer/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/which": {
@@ -2363,6 +2664,15 @@
 		}
 	},
 	"dependencies": {
+		"@babel/runtime": {
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+			"integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+			"dev": true,
+			"requires": {
+				"regenerator-runtime": "^0.14.0"
+			}
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"dev": true,
@@ -2399,6 +2709,12 @@
 		},
 		"@ungap/promise-all-settled": {
 			"version": "1.1.2",
+			"dev": true
+		},
+		"@vscode/web-custom-data": {
+			"version": "0.4.12",
+			"resolved": "https://registry.npmjs.org/@vscode/web-custom-data/-/web-custom-data-0.4.12.tgz",
+			"integrity": "sha512-bCemuvwCC84wJQbJoaPou86sjz9DUvZgGa6sAWQwzw7oIELD7z+WnUj2Rdsu8/8XPhKLcg3IswQ2+Pm3OMinIg==",
 			"dev": true
 		},
 		"ansi-colors": {
@@ -2493,10 +2809,12 @@
 			}
 		},
 		"braces": {
-			"version": "3.0.2",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"requires": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			}
 		},
 		"browser-stdout": {
@@ -2709,6 +3027,17 @@
 			"version": "2.0.1",
 			"dev": true
 		},
+		"didyoumean2": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/didyoumean2/-/didyoumean2-4.1.0.tgz",
+			"integrity": "sha512-qTBmfQoXvhKO75D/05C8m+fteQmn4U46FWYiLhXtZQInzitXLWY0EQ/2oKnpAz9g2lQWW8jYcLcT+hPJGT+kig==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.10.2",
+				"leven": "^3.1.0",
+				"lodash.deburr": "^4.1.0"
+			}
+		},
 		"diff": {
 			"version": "5.0.0",
 			"dev": true
@@ -2828,7 +3157,9 @@
 			}
 		},
 		"fill-range": {
-			"version": "7.0.1",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"
@@ -3013,6 +3344,8 @@
 		},
 		"is-number": {
 			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true
 		},
 		"is-plain-obj": {
@@ -3057,12 +3390,93 @@
 				"uc.micro": "^1.0.1"
 			}
 		},
+		"lit-analyzer": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/lit-analyzer/-/lit-analyzer-2.0.3.tgz",
+			"integrity": "sha512-XiAjnwVipNrKav7r3CSEZpWt+mwYxrhPRVC7h8knDmn/HWTzzWJvPe+mwBcL2brn4xhItAMzZhFC8tzzqHKmiQ==",
+			"dev": true,
+			"requires": {
+				"@vscode/web-custom-data": "^0.4.2",
+				"chalk": "^2.4.2",
+				"didyoumean2": "4.1.0",
+				"fast-glob": "^3.2.11",
+				"parse5": "5.1.0",
+				"ts-simple-type": "~2.0.0-next.0",
+				"vscode-css-languageservice": "4.3.0",
+				"vscode-html-languageservice": "3.1.0",
+				"web-component-analyzer": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
 		"locate-path": {
 			"version": "6.0.0",
 			"dev": true,
 			"requires": {
 				"p-locate": "^5.0.0"
 			}
+		},
+		"lodash.deburr": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
+			"integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
+			"dev": true
 		},
 		"log-symbols": {
 			"version": "4.1.0",
@@ -3268,6 +3682,12 @@
 				"semver": "^5.1.0"
 			}
 		},
+		"parse5": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+			"dev": true
+		},
 		"parse5-htmlparser2-tree-adapter": {
 			"version": "6.0.1",
 			"dev": true,
@@ -3394,6 +3814,12 @@
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+			"dev": true
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -3547,10 +3973,18 @@
 		},
 		"to-regex-range": {
 			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
 			"requires": {
 				"is-number": "^7.0.0"
 			}
+		},
+		"ts-simple-type": {
+			"version": "2.0.0-next.0",
+			"resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-2.0.0-next.0.tgz",
+			"integrity": "sha512-A+hLX83gS+yH6DtzNAhzZbPfU+D9D8lHlTSd7GeoMRBjOt3GRylDqLTYbdmjA4biWvq2xSfpqfIDj2l0OA/BVg==",
+			"dev": true
 		},
 		"tslib": {
 			"version": "2.3.1",
@@ -3671,6 +4105,132 @@
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
+				}
+			}
+		},
+		"vscode-css-languageservice": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-4.3.0.tgz",
+			"integrity": "sha512-BkQAMz4oVHjr0oOAz5PdeE72txlLQK7NIwzmclfr+b6fj6I8POwB+VoXvrZLTbWt9hWRgfvgiQRkh5JwrjPJ5A==",
+			"dev": true,
+			"requires": {
+				"vscode-languageserver-textdocument": "^1.0.1",
+				"vscode-languageserver-types": "3.16.0-next.2",
+				"vscode-nls": "^4.1.2",
+				"vscode-uri": "^2.1.2"
+			}
+		},
+		"vscode-html-languageservice": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-3.1.0.tgz",
+			"integrity": "sha512-QAyRHI98bbEIBCqTzZVA0VblGU40na0txggongw5ZgTj9UVsVk5XbLT16O9OTcbqBGSqn0oWmFDNjK/XGIDcqg==",
+			"dev": true,
+			"requires": {
+				"vscode-languageserver-textdocument": "^1.0.1",
+				"vscode-languageserver-types": "3.16.0-next.2",
+				"vscode-nls": "^4.1.2",
+				"vscode-uri": "^2.1.2"
+			}
+		},
+		"vscode-languageserver-textdocument": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+			"dev": true
+		},
+		"vscode-languageserver-types": {
+			"version": "3.16.0-next.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
+			"integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==",
+			"dev": true
+		},
+		"vscode-nls": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
+			"integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw==",
+			"dev": true
+		},
+		"vscode-uri": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
+			"integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==",
+			"dev": true
+		},
+		"web-component-analyzer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0.tgz",
+			"integrity": "sha512-UEvwfpD+XQw99sLKiH5B1T4QwpwNyWJxp59cnlRwFfhUW6JsQpw5jMeMwi7580sNou8YL3kYoS7BWLm+yJ/jVQ==",
+			"dev": true,
+			"requires": {
+				"fast-glob": "^3.2.2",
+				"ts-simple-type": "2.0.0-next.0",
+				"typescript": "~5.2.0",
+				"yargs": "^17.7.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"cliui": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+					"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.1",
+						"wrap-ansi": "^7.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				},
+				"yargs": {
+					"version": "17.7.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+					"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+					"dev": true,
+					"requires": {
+						"cliui": "^8.0.1",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"require-directory": "^2.1.1",
+						"string-width": "^4.2.3",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^21.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "21.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+					"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+					"dev": true
 				}
 			}
 		},


### PR DESCRIPTION
The old versions were no longer supported on GitHub Actions.

Also node: "17" was not in the list of node versions to exclude in the strategy.

Validated the changes on this nice tool:
https://rhysd.github.io/actionlint/