### PR TITLE
Support the latest css and html entities

### DIFF
--- a/packages/lit-analyzer/package-lock.json
+++ b/packages/lit-analyzer/package-lock.json
@@ -15,8 +15,8 @@
 				"fast-glob": "^3.2.11",
 				"parse5": "5.1.0",
 				"ts-simple-type": "~2.0.0-next.0",
-				"vscode-css-languageservice": "6.2.12",
-				"vscode-html-languageservice": "5.1.2",
+				"vscode-css-languageservice": "6.3.7",
+				"vscode-html-languageservice": "5.5.1",
 				"web-component-analyzer": "^2.0.0"
 			},
 			"bin": {
@@ -3865,31 +3865,31 @@
 			}
 		},
 		"node_modules/vscode-css-languageservice": {
-			"version": "6.2.12",
-			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.12.tgz",
-			"integrity": "sha512-PS9r7HgNjqzRl3v91sXpCyZPc8UDotNo6gntFNtGCKPhGA9Frk7g/VjX1Mbv3F00pn56D+rxrFzR9ep4cawOgA==",
+			"version": "6.3.7",
+			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.7.tgz",
+			"integrity": "sha512-5TmXHKllPzfkPhW4UE9sODV3E0bIOJPOk+EERKllf2SmAczjfTmYeq5txco+N3jpF8KIZ6loj/JptpHBQuVQRA==",
 			"dependencies": {
 				"@vscode/l10n": "^0.0.18",
-				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-textdocument": "^1.0.12",
 				"vscode-languageserver-types": "3.17.5",
-				"vscode-uri": "^3.0.8"
+				"vscode-uri": "^3.1.0"
 			}
 		},
 		"node_modules/vscode-html-languageservice": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.1.2.tgz",
-			"integrity": "sha512-wkWfEx/IIR3s2P5yD4aTGHiOb8IAzFxgkSt1uSC3itJ4oDAm23yG7o0L29JljUdnXDDgLafPAvhv8A2I/8riHw==",
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.5.1.tgz",
+			"integrity": "sha512-/ZdEtsZ3OiFSyL00kmmu7crFV9KwWR+MgpzjsxO60DQH7sIfHZM892C/E4iDd11EKocr+NYuvOA4Y7uc3QzLEA==",
 			"dependencies": {
 				"@vscode/l10n": "^0.0.18",
-				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-textdocument": "^1.0.12",
 				"vscode-languageserver-types": "^3.17.5",
-				"vscode-uri": "^3.0.8"
+				"vscode-uri": "^3.1.0"
 			}
 		},
 		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
-			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
 		},
 		"node_modules/vscode-languageserver-types": {
 			"version": "3.17.5",
@@ -3897,9 +3897,9 @@
 			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
 		},
 		"node_modules/vscode-uri": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="
 		},
 		"node_modules/wcwidth": {
 			"version": "1.0.1",
@@ -6933,31 +6933,31 @@
 			}
 		},
 		"vscode-css-languageservice": {
-			"version": "6.2.12",
-			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.12.tgz",
-			"integrity": "sha512-PS9r7HgNjqzRl3v91sXpCyZPc8UDotNo6gntFNtGCKPhGA9Frk7g/VjX1Mbv3F00pn56D+rxrFzR9ep4cawOgA==",
+			"version": "6.3.7",
+			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.7.tgz",
+			"integrity": "sha512-5TmXHKllPzfkPhW4UE9sODV3E0bIOJPOk+EERKllf2SmAczjfTmYeq5txco+N3jpF8KIZ6loj/JptpHBQuVQRA==",
 			"requires": {
 				"@vscode/l10n": "^0.0.18",
-				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-textdocument": "^1.0.12",
 				"vscode-languageserver-types": "3.17.5",
-				"vscode-uri": "^3.0.8"
+				"vscode-uri": "^3.1.0"
 			}
 		},
 		"vscode-html-languageservice": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.1.2.tgz",
-			"integrity": "sha512-wkWfEx/IIR3s2P5yD4aTGHiOb8IAzFxgkSt1uSC3itJ4oDAm23yG7o0L29JljUdnXDDgLafPAvhv8A2I/8riHw==",
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.5.1.tgz",
+			"integrity": "sha512-/ZdEtsZ3OiFSyL00kmmu7crFV9KwWR+MgpzjsxO60DQH7sIfHZM892C/E4iDd11EKocr+NYuvOA4Y7uc3QzLEA==",
 			"requires": {
 				"@vscode/l10n": "^0.0.18",
-				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-languageserver-textdocument": "^1.0.12",
 				"vscode-languageserver-types": "^3.17.5",
-				"vscode-uri": "^3.0.8"
+				"vscode-uri": "^3.1.0"
 			}
 		},
 		"vscode-languageserver-textdocument": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
-			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
 		},
 		"vscode-languageserver-types": {
 			"version": "3.17.5",
@@ -6965,9 +6965,9 @@
 			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
 		},
 		"vscode-uri": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="
 		},
 		"wcwidth": {
 			"version": "1.0.1",

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -94,8 +94,8 @@
 		"fast-glob": "^3.2.11",
 		"parse5": "5.1.0",
 		"ts-simple-type": "~2.0.0-next.0",
-		"vscode-css-languageservice": "6.2.12",
-		"vscode-html-languageservice": "5.1.2",
+		"vscode-css-languageservice": "6.3.7",
+		"vscode-html-languageservice": "5.5.1",
 		"web-component-analyzer": "^2.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Update vscode-css-languageservice and vscode-html-languageservice versions
    
To support the latest css and html entities (properties, at-rules, etc) For example: text-wrap: pretty; and do not produce errors for it.